### PR TITLE
Spell Import: Create Saving Throw Spell Type

### DIFF
--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -175,6 +175,13 @@ let getRange = data => {
 
 let getActionType = data => {
   if (
+    data.definition.requiresSavingThrow &&
+    !data.definition.requiresAttackRoll
+  ) {
+    return "save";
+  }
+
+  if (
     data.definition.tags.includes("Damage") &&
     data.definition.range.rangeValue &&
     data.definition.range.rangeValue > 0


### PR DESCRIPTION
This fixes the import to save spells on the character sheet as Saving
Throw based rather than attack base, if they are listed as such.

If a spell requires a saving throw and an attack, it defaults to attack.
The logic in this case will still add a saving throw.

I tested this with the Ice Dagger spell.

This fixes the character sheet import part of #11