### PR TITLE
Mark spell as utility if it has buff tag

### DIFF
--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -197,6 +197,10 @@ let getActionType = data => {
     return "heal";
   }
 
+  if (data.definition.tags.includes("Buff")) {
+    return "util";
+  }
+
   return "other";
 };
 


### PR DESCRIPTION
After other spell filtering, if the spell has the `Buff` tag then mark it as a utility like the spell importer does in the chrome extension.