### PR TITLE
Arcane trickster support

### DIFF
--- a/src/parser/character/index.js
+++ b/src/parser/character/index.js
@@ -314,26 +314,46 @@ let getSpeed = (data, character) => {
   };
 };
 
+// is there a spell casting ability?
+let hasSpellCastingAbility = spellCastingAbilityId => {
+  return DICTIONARY.character.abilities.find(
+    ability => ability.id === spellCastingAbilityId
+  ) !== undefined;
+};
+
+// convert spellcasting ability id to string used by vtta
+let convertSpellCastingAbilityId = spellCastingAbilityId => {
+  return DICTIONARY.character.abilities.find(
+    ability => ability.id === spellCastingAbilityId
+  ).value;
+};
+
 let getSpellCasting = (data, character) => {
   let result = [];
   data.character.classSpells.forEach(playerClass => {
     let classInfo = data.character.classes.find(
       cls => cls.id === playerClass.characterClassId
     );
-    let hasSpellCastingAbility =
-      DICTIONARY.character.abilities.find(
-        ability => ability.id === classInfo.definition.spellCastingAbilityId
-      ) !== undefined;
     let spellCastingAbility = undefined;
-    if (hasSpellCastingAbility) {
-      spellCastingAbility = DICTIONARY.character.abilities.find(
-        ability => ability.id === classInfo.definition.spellCastingAbilityId
-      ).value;
+    if (hasSpellCastingAbility(classInfo.definition.spellCastingAbilityId)) {
+      // check to see if class has a spell casting ability
+      spellCastingAbility = convertSpellCastingAbilityId(
+        classInfo.definition.spellCastingAbilityId
+      );
+    } else if (hasSpellCastingAbility(
+        classInfo.subclassDefinition.spellCastingAbilityId
+      )) {
+      //some subclasses attach a spellcasting ability, e.g. Arcane Trickster
+      spellCastingAbility = convertSpellCastingAbilityId(
+        classInfo.subclassDefinition.spellCastingAbilityId
+      );
+    };
+    if (spellCastingAbility !== undefined) {
       let abilityModifier = utils.calculateModifier(
         character.data.abilities[spellCastingAbility].value
       );
-      result.push({ label: spellCastingAbility, value: abilityModifier });
-    }
+      result.push({ label: spellCastingAbility, value: abilityModifier })
+    };
   });
   // we need to decide on one spellcasting ability, so we take the one with the highest modifier
   if (result.length === 0) {

--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -415,12 +415,6 @@ export default function parseSpells(ddb, character) {
         character.data.abilities[spellCastingAbility].value
       );
 
-      // does this class needs to prepare spells?
-      let preparesSpells =
-        classInfo.definition.spellPrepareType === 1 ||
-        (classInfo.subclassDefinition &&
-          classInfo.subclassDefinition.spellPrepareType === 1);
-
       playerClass.spells.forEach(spell => {
         // add some data for the parsing of the spells into the data structure
         spell.flags = {

--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -330,6 +330,43 @@ let getFormula = data => {
   }
 };
 
+// is there a spell casting ability?
+let hasSpellCastingAbility = spellCastingAbilityId => {
+  return DICTIONARY.character.abilities.find(
+    ability => ability.id === spellCastingAbilityId
+  ) !== undefined;
+};
+
+// convert spellcasting ability id to string used by vtta
+let convertSpellCastingAbilityId = spellCastingAbilityId => {
+  return DICTIONARY.character.abilities.find(
+    ability => ability.id === spellCastingAbilityId
+  ).value;
+};
+
+// search through classinfo and determine spellcasting ability
+let getSpellCastingAbility = classInfo => {
+  let spellCastingAbility = undefined;
+  if (hasSpellCastingAbility(
+    classInfo.definition.spellCastingAbilityId
+  )) {
+    spellCastingAbility = convertSpellCastingAbilityId(
+      classInfo.definition.spellCastingAbilityId
+    );
+  } else if (hasSpellCastingAbility(
+    classInfo.subclassDefinition.spellCastingAbilityId
+  )) {
+    // Arcane Trickster has spellcasting ID granted here
+    spellCastingAbility = convertSpellCastingAbilityId(
+      classInfo.subclassDefinition.spellCastingAbilityId
+    );
+  } else {
+    // special cases: No spellcaster, but can cast spells like totem barbarian, default to wis
+    spellCastingAbility = "wis";
+  };
+  return spellCastingAbility;
+};
+
 let parseSpell = (data, character) => {
   /**
    * MAIN parseSpell
@@ -391,88 +428,134 @@ let parseSpell = (data, character) => {
 
   spell.data.formula = getFormula(data);
 
+  // attach the spell ability id to the spell data so VTT always uses the
+  // correct one, useful if multi-classing and spells have different 
+  // casting abilities
+  if (character.data.attributes.spellcasting !== 
+    data.flags.vtta.dndbeyond.ability
+  ) {
+    spell.data.ability = data.flags.vtta.dndbeyond.ability;
+  };
+
   return spell;
 };
 
 export default function parseSpells(ddb, character) {
   let items = [];
+  let proficiencyModifier = character.data.attributes.prof;
 
+  // each class has an entry here, each entry has spells
+  // we loop through each class and process
   ddb.character.classSpells.forEach(playerClass => {
     let classInfo = ddb.character.classes.find(
       cls => cls.id === playerClass.characterClassId
     );
-    let hasSpellCastingAbility =
-      DICTIONARY.character.abilities.find(
-        ability => ability.id === classInfo.definition.spellCastingAbilityId
-      ) !== undefined;
-    let spellCastingAbility = undefined;
-    if (hasSpellCastingAbility) {
-      spellCastingAbility = DICTIONARY.character.abilities.find(
-        ability => ability.id === classInfo.definition.spellCastingAbilityId
-      ).value;
-      let proficiencyModifier = Math.ceil(1 + 0.25 * classInfo.level);
-      let abilityModifier = utils.calculateModifier(
-        character.data.abilities[spellCastingAbility].value
-      );
+    console.log(JSON.stringify(classInfo));
+    let spellCastingAbility = getSpellCastingAbility(classInfo);
+    let abilityModifier = utils.calculateModifier(
+      character.data.abilities[spellCastingAbility].value
+    );
 
-      playerClass.spells.forEach(spell => {
-        // add some data for the parsing of the spells into the data structure
-        spell.flags = {
-          vtta: {
-            dndbeyond: {
-              class: classInfo.definition.name,
-              level: classInfo.level,
-              ability: spellCastingAbility,
-              mod: abilityModifier,
-              dc: 8 + proficiencyModifier + abilityModifier
-            }
+    // parse spells chosen as spellcasting (playerClass.spells)
+    playerClass.spells.forEach(spell => {
+      // add some data for the parsing of the spells into the data structure
+      spell.flags = {
+        vtta: {
+          dndbeyond: {
+            class: classInfo.definition.name,
+            level: classInfo.level,
+            ability: spellCastingAbility,
+            mod: abilityModifier,
+            dc: 8 + proficiencyModifier + abilityModifier
           }
-        };
-
-        // do not parse the same spell twice. Had it once with Spiritual Weapons with the same
-        // data, but only a different spell ID
-        if (
-          items.find(
-            existingSpell => existingSpell.name === spell.definition.name
-          ) === undefined
-        ) {
-          items.push(parseSpell(spell));
         }
-      });
-    } else {
-      // special cases: No spellcaster, but can cast spells like totem barbarian
-      spellCastingAbility = "wis";
-      let proficiencyModifier = Math.ceil(1 + 0.25 * classInfo.level);
-      let abilityModifier = utils.calculateModifier(
-        character.data.abilities[spellCastingAbility].value
+      };
+
+      // do not parse the same spell twice. Had it once with Spiritual Weapons with the same
+      // data, but only a different spell ID
+      if (
+        items.find(
+          existingSpell => existingSpell.name === spell.definition.name
+        ) === undefined
+      ) {
+        items.push(parseSpell(spell, character));
+      };
+    });
+  });
+
+  // Parse any spells granted by class features, such as Barbarian Totem
+  ddb.character.spells.class.forEach(spell => {
+    let spellCastingAbility = undefined;
+    // If the spell has an ability attached, use that
+    if (hasSpellCastingAbility(spell.spellCastingAbilityId)) {
+      spellCastingAbility = convertSpellCastingAbilityId(
+        spell.spellCastingAbilityId
       );
+    } else {
+      // if there is no ability on spell, we default to wis
+      spellCastingAbility = "wis";
+    };
 
-      [ddb.character.spells.race, ddb.character.spells.class]
-        .flat()
-        .forEach(spell => {
-          // add some data for the parsing of the spells into the data structure
-          spell.flags = {
-            vtta: {
-              dndbeyond: {
-                class: classInfo.definition.name,
-                level: classInfo.level,
-                ability: spellCastingAbility,
-                mod: abilityModifier,
-                dc: 8 + proficiencyModifier + abilityModifier
-              }
-            }
-          };
+    let abilityModifier = utils.calculateModifier(
+      character.data.abilities[spellCastingAbility].value
+    );
 
-          // do not parse the same spell twice. Had it once with Spiritual Weapons with the same
-          // data, but only a different spell ID
-          if (
-            items.find(
-              existingSpell => existingSpell.name === spell.definition.name
-            ) === undefined
-          ) {
-            items.push(parseSpell(spell));
-          }
-        });
+    // add some data for the parsing of the spells into the data structure
+    spell.flags = {
+      vtta: {
+        dndbeyond: {
+          class: "Class Ability", // it's impossible to know which class granted these
+          level: character.data.details.level.value,
+          ability: spellCastingAbility,
+          mod: abilityModifier,
+          dc: 8 + proficiencyModifier + abilityModifier
+        }
+      }
+    };
+
+    // do not parse the same spell twice. Had it once with Spiritual Weapons with the same
+    // data, but only a different spell ID
+    if (
+      items.find(
+        existingSpell => existingSpell.name === spell.definition.name
+      ) === undefined
+    ) {
+      items.push(parseSpell(spell, character));
+    };
+  });
+
+  // Race spells are handled slightly differently
+  ddb.character.spells.race.forEach(spell => {
+    // for race spells the spell spellCastingAbilityId is on the spell
+    let spellCastingAbility = convertSpellCastingAbilityId(
+      spell.spellCastingAbilityId
+    );
+
+    let abilityModifier = utils.calculateModifier(
+      character.data.abilities[spellCastingAbility].value
+    );
+
+    // add some data for the parsing of the spells into the data structure
+    spell.flags = {
+      vtta: {
+        dndbeyond: {
+          class: ddb.character.race.fullName,
+          level: spell.castAtLevel,
+          ability: spellCastingAbility,
+          mod: abilityModifier,
+          dc: 8 + proficiencyModifier + abilityModifier
+        }
+      }
+    };
+
+    // do not parse the same spell twice. Had it once with Spiritual Weapons with the same
+    // data, but only a different spell ID
+    if (
+      items.find(
+        existingSpell => existingSpell.name === spell.definition.name
+      ) === undefined
+    ) {
+      items.push(parseSpell(spell, character));
     }
   });
 

--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -422,11 +422,40 @@ export default function parseSpells(ddb, character) {
           classInfo.subclassDefinition.spellPrepareType === 1);
 
       playerClass.spells.forEach(spell => {
+        // add some data for the parsing of the spells into the data structure
+        spell.flags = {
+          vtta: {
+            dndbeyond: {
+              class: classInfo.definition.name,
+              level: classInfo.level,
+              ability: spellCastingAbility,
+              mod: abilityModifier,
+              dc: 8 + proficiencyModifier + abilityModifier
+            }
+          }
+        };
+
+        // do not parse the same spell twice. Had it once with Spiritual Weapons with the same
+        // data, but only a different spell ID
         if (
-          spell.definition.level === 0 ||
-          (preparesSpells && (spell.prepared || spell.alwaysPrepared)) ||
-          !preparesSpells
+          items.find(
+            existingSpell => existingSpell.name === spell.definition.name
+          ) === undefined
         ) {
+          items.push(parseSpell(spell));
+        }
+      });
+    } else {
+      // special cases: No spellcaster, but can cast spells like totem barbarian
+      spellCastingAbility = "wis";
+      let proficiencyModifier = Math.ceil(1 + 0.25 * classInfo.level);
+      let abilityModifier = utils.calculateModifier(
+        character.data.abilities[spellCastingAbility].value
+      );
+
+      [ddb.character.spells.race, ddb.character.spells.class]
+        .flat()
+        .forEach(spell => {
           // add some data for the parsing of the spells into the data structure
           spell.flags = {
             vtta: {
@@ -448,53 +477,6 @@ export default function parseSpells(ddb, character) {
             ) === undefined
           ) {
             items.push(parseSpell(spell));
-          }
-        }
-      });
-    } else {
-      // special cases: No spellcaster, but can cast spells like totem barbarian
-      spellCastingAbility = "wis";
-      let proficiencyModifier = Math.ceil(1 + 0.25 * classInfo.level);
-      let abilityModifier = utils.calculateModifier(
-        character.data.abilities[spellCastingAbility].value
-      );
-
-      // does this class needs to prepare spells?
-      let preparesSpells =
-        classInfo.definition.spellPrepareType === 1 ||
-        (classInfo.subclassDefinition &&
-          classInfo.subclassDefinition.spellPrepareType === 1);
-
-      [ddb.character.spells.race, ddb.character.spells.class]
-        .flat()
-        .forEach(spell => {
-          if (
-            spell.definition.level === 0 ||
-            (preparesSpells && (spell.prepared || spell.alwaysPrepared)) ||
-            !preparesSpells
-          ) {
-            // add some data for the parsing of the spells into the data structure
-            spell.flags = {
-              vtta: {
-                dndbeyond: {
-                  class: classInfo.definition.name,
-                  level: classInfo.level,
-                  ability: spellCastingAbility,
-                  mod: abilityModifier,
-                  dc: 8 + proficiencyModifier + abilityModifier
-                }
-              }
-            };
-
-            // do not parse the same spell twice. Had it once with Spiritual Weapons with the same
-            // data, but only a different spell ID
-            if (
-              items.find(
-                existingSpell => existingSpell.name === spell.definition.name
-              ) === undefined
-            ) {
-              items.push(parseSpell(spell));
-            }
           }
         });
     }

--- a/src/parser/dictionary.js
+++ b/src/parser/dictionary.js
@@ -377,6 +377,7 @@ const DICTIONARY = {
             /*
             { name: 'Hunter', value: 'always' },
             { name: 'Bard', value: 'always' },
+            { name: 'Rogue', value: 'always' },
             { name: 'Sorcerer', value: 'always' },
             { name: 'Artificer', value: 'always' },
             { name: 'Cleric', value: 'prepared' },
@@ -388,6 +389,7 @@ const DICTIONARY = {
             // this table works for the current Foundry UI
             { name: 'Hunter', value: 'prepared' },
             { name: 'Bard', value: 'prepared' },
+            { name: 'Rogue', value: 'prepared' },
             { name: 'Sorcerer', value: 'prepared' },
             { name: 'Artificer', value: 'prepared' },
             { name: 'Cleric', value: 'prepared' },


### PR DESCRIPTION
Adds support for Arcane Trickster and similar subclasses that grant
spells.

It improves the accuracy of some metadata and moves a complicated block
to it's own function.

It allows for the correct ability score to be selected if you multiclass
and have spells with different DC's.

This is based of #21 