### PR TITLE
Spell imports: Feats, Races, & Warlock improvements

### DIFF
--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -73,18 +73,18 @@ let getSpellPreparationMode = data => {
       return {
         //TODO warlock sets spell slots on normal spells, not pact spells.
         mode: prepMode.value,
-        prepared: data.prepared
+        prepared: data.alwaysPrepared || data.prepared
       };
     } else {
       return {
         mode: "prepared",
-        prepared: data.prepared
+        prepared: data.alwaysPrepared || data.prepared
       };
     }
-  } else { // TODO add race and class features
+  } else { // TODO add feat, race and class features
     return {
       mode: "prepared",
-      prepared: data.prepared
+      prepared: data.alwaysPrepared || data.prepared
     };
   };
 };

--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -469,22 +469,27 @@ let getLookups = (character) => {
   })
 
   character.classes.forEach( playerClass => {
-    [playerClass.definition, playerClass.subclassDefinition]
-    .flat()
-    .forEach( trait => {
-      lookups.class.push({
-        id: trait.id,
-        name: trait.name,
-      })
+    lookups.class.push({
+      id: playerClass.definition.id,
+      name: playerClass.definition.name,
     });
 
-    playerClass.classFeatures.forEach( trait => {
-      lookups.classFeature.push({
-        id: trait.definition.id,
-        name: trait.definition.name,
-        componentId: trait.definition.componentId,
+    if (playerClass.subclassDefinition) {
+      lookups.class.push({
+        id: playerClass.subclassDefinition.id,
+        name: playerClass.subclassDefinition.name,
+      })
+    };
+
+    if (playerClass.classFeatures) {
+      playerClass.classFeatures.forEach( trait => {
+        lookups.classFeature.push({
+          id: trait.definition.id,
+          name: trait.definition.name,
+          componentId: trait.definition.componentId,
+        });
       });
-    });
+    };
   });
 
   character.options.class.forEach( trait => {

--- a/src/parser/dictionary.js
+++ b/src/parser/dictionary.js
@@ -1,4 +1,12 @@
 const DICTIONARY = {
+    resets: [
+        { id: 1, value: 'sr' },
+        { id: 'ShortRest', value: 'sr' },
+        { id: 2, value: 'lr' },
+        { id: 'LongRest', value: 'lr' },
+        { id: 'Dawn', value: 'day' },
+        { id: 'Consumable', value: 'charges' },
+    ],
     character: {
         abilities: [
             { id: 1, value: 'str', long: 'strength' },


### PR DESCRIPTION
This PR:

* Now imports Feat and Race spells
* All spells that are prepared for casters are loaded prepared. e.g. Cleric domain spells, and additional spells for Paladins.
* Spells with restricted useage now has this imported. e.g. racial spells, and Mystic Arcanum spells.
* Make Warlock use prepared spells, not pact based for levels 1-5, due to no spell slot support in VTT for pact magic
* Make sure ritual only spells are never prepared for casters, e.g. book of ancient secrets and totem barb
* Import racial spells as innate spells
* Fix spellscale scaling, it should return `level` for VTT to use it, returning `spellscale` sets the value to None.
* Allow Warlock Mystic Arcanum spells to import
* Fix a bug where the target never came through
* Added a lookup function to get metafata/flag about where feat , race and class feature spells come from.
