### PR TITLE
Improved Items Support

### DIFF
--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -672,8 +672,8 @@ export default function parseSpells(ddb, character) {
 
   // Parse any spells granted by class features, such as Barbarian Totem
   ddb.character.spells.class.forEach(spell => {
-    let spellCastingAbility = undefined;
     // If the spell has an ability attached, use that
+    let spellCastingAbility = undefined;
     if (hasSpellCastingAbility(spell.spellCastingAbilityId)) {
       spellCastingAbility = convertSpellCastingAbilityId(
         spell.spellCastingAbilityId
@@ -712,15 +712,14 @@ export default function parseSpells(ddb, character) {
   // Race spells are handled slightly differently
   ddb.character.spells.race.forEach(spell => {
     let spellCastingAbility = undefined;
-    // If the spell has an ability attached, use that
+    // for race spells the spell spellCastingAbilityId is on the spell
+    // if there is no ability on spell, we default to wis
+    let spellCastingAbility = "wis";
     if (hasSpellCastingAbility(spell.spellCastingAbilityId)) {
       spellCastingAbility = convertSpellCastingAbilityId(
         spell.spellCastingAbilityId
       );
-    } else {
-      // if there is no ability on spell, we default to wis
-      spellCastingAbility = "wis";
-    }
+    };
 
     let abilityModifier = utils.calculateModifier(
       character.data.abilities[spellCastingAbility].value
@@ -751,16 +750,14 @@ export default function parseSpells(ddb, character) {
 
   // feat spells are handled slightly differently
   ddb.character.spells.feat.forEach(spell => {
-    let spellCastingAbility = undefined;
     // If the spell has an ability attached, use that
+    // if there is no ability on spell, we default to wis
+    let spellCastingAbility = "wis";
     if (hasSpellCastingAbility(spell.spellCastingAbilityId)) {
       spellCastingAbility = convertSpellCastingAbilityId(
         spell.spellCastingAbilityId
       );
-    } else {
-      // if there is no ability on spell, we default to wis
-      spellCastingAbility = "wis";
-    }
+    };
 
     let abilityModifier = utils.calculateModifier(
       character.data.abilities[spellCastingAbility].value
@@ -805,9 +802,14 @@ export default function parseSpells(ddb, character) {
       if (spell.overrideSaveDc) {
         spellDC = spell.overrideSaveDc;
       } else if (spell.spellCastingAbilityId) {
-        let spellCastingAbility = convertSpellCastingAbilityId(
-          spell.spellCastingAbilityId
-        );
+        // If the spell has an ability attached, use that
+        // if there is no ability on spell, we default to wis
+        let spellCastingAbility = "wis";
+        if (hasSpellCastingAbility(spell.spellCastingAbilityId)) {
+          spellCastingAbility = convertSpellCastingAbilityId(
+            spell.spellCastingAbilityId
+          );
+        };
     
         let abilityModifier = utils.calculateModifier(
           character.data.abilities[spellCastingAbility].value

--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -711,7 +711,6 @@ export default function parseSpells(ddb, character) {
 
   // Race spells are handled slightly differently
   ddb.character.spells.race.forEach(spell => {
-    let spellCastingAbility = undefined;
     // for race spells the spell spellCastingAbilityId is on the spell
     // if there is no ability on spell, we default to wis
     let spellCastingAbility = "wis";

--- a/src/parser/dictionary.js
+++ b/src/parser/dictionary.js
@@ -6,6 +6,7 @@ const DICTIONARY = {
         { id: 'LongRest', value: 'lr' },
         { id: 'Dawn', value: 'day' },
         { id: 'Consumable', value: 'charges' },
+        { id: 'Other', value: 'charges' },
     ],
     character: {
         abilities: [

--- a/src/parser/inventory/armor.js
+++ b/src/parser/inventory/armor.js
@@ -111,7 +111,28 @@ let getEquipped = data => {
     return data.equipped;
 };
 
-export default function parseEquipment(data, character) {
+/**
+ * Gets Limited uses information, if any
+ * uses: { value: 0, max: 0, per: null }
+ */
+let getUses = data => {
+  if (data.limitedUse !== undefined && data.limitedUse !== null){
+    let resetType = DICTIONARY.resets.find(
+      reset => reset.id == data.limitedUse.resetType
+    );
+    return {
+      max: data.limitedUse.maxUses,
+      value: data.limitedUse.numberUsed
+        ? data.limitedUse.maxUses - data.limitedUse.numberUsed
+        : data.limitedUse.maxUses,
+      per: resetType.value,
+    };
+  } else {
+    return { value: 0, max: 0, per: null };
+  };
+};
+
+export default function parseArmor(data, character) {
   /**
    * MAIN parseEquipment
    */
@@ -186,6 +207,8 @@ export default function parseEquipment(data, character) {
 
   /* identified: true, */
   armor.data.identified = true;
+
+  armor.data.uses = getUses(data);
 
   return armor;
 }

--- a/src/parser/inventory/index.js
+++ b/src/parser/inventory/index.js
@@ -5,7 +5,10 @@ import parseAmmunition from './ammunition.js';
 import parseStaff from './staves.js';
 
 // type: armor
-import parseEquipment from './equipment.js';
+import parseArmor from './armor.js';
+
+// tyoe: wonderous item
+import parseWonderous from './wonderous.js';
 
 // type: consumables
 import parsePotion from './potion.js';
@@ -29,15 +32,18 @@ let parseItem = (data, character) => {
           return parseWeapon(data, character);
         }
         break;
-
       case 'Armor':
-        return parseEquipment(data, character);
+        return parseArmor(data, character);
         break;
-
+      case 'Wondrous item':
+      case 'Ring':
+      case 'Wand':
+      case 'Rod':
+        return parseWonderous(data,character);
+        break
       case 'Staff':
         return parseStaff(data, character);
         break;
-
       case 'Potion':
         return parsePotion(data, character);
         break;

--- a/src/parser/inventory/potion.js
+++ b/src/parser/inventory/potion.js
@@ -3,35 +3,26 @@ import utils from "../../utils.js";
 
 /**
  * Gets Limited uses information, if any
+ * uses: { value: 0, max: 0, per: null, autoUse: false, autoDestroy: false };
  */
 let getUses = data => {
-  // uses: { value: 0, max: 0, per: null }
-  if (data.limitedUse) {
-    if (data.limitedUse.resetType === "Consumable") {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges",
-        autoUse: false,
-        autoDestroy: true
-      };
-    } else {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges",
-        autoUse: false,
-        autoDestroy: true
-      };
-    }
+  if (data.limitedUse !== undefined && data.limitedUse !== null){
+    let resetType = DICTIONARY.resets.find(
+      reset => reset.id == data.limitedUse.resetType
+    );
+    return {
+      max: data.limitedUse.maxUses,
+      value: data.limitedUse.numberUsed
+        ? data.limitedUse.maxUses - data.limitedUse.numberUsed
+        : data.limitedUse.maxUses,
+      per: resetType.value,
+      autoUse: false,
+      autoDestroy: true,
+    };
   } else {
-    // default
     return { value: 0, max: 0, per: null, autoUse: false, autoDestroy: false };
-  }
+  };
+  
 };
 
 /**
@@ -198,6 +189,8 @@ export default function parsePotion(data, character) {
   consumable.data.actionType = getActionType(data);
 
   consumable.data.damage = getDamage(data, getActionType(data));
+
+  consumable.data.uses = getUses(data);
 
   return consumable;
 }

--- a/src/parser/inventory/staves.js
+++ b/src/parser/inventory/staves.js
@@ -114,31 +114,23 @@ let getRange = data => {
 
 /**
  * Gets Limited uses information, if any
+ * uses: { value: 0, max: 0, per: null }
  */
 let getUses = data => {
-  // uses: { value: 0, max: 0, per: null }
-  if (data.limitedUse) {
-    if (data.limitedUse.resetType === "Consumable") {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges"
-      };
-    } else {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges"
-      };
-    }
+  if (data.limitedUse !== undefined && data.limitedUse !== null){
+    let resetType = DICTIONARY.resets.find(
+      reset => reset.id == data.limitedUse.resetType
+    );
+    return {
+      max: data.limitedUse.maxUses,
+      value: data.limitedUse.numberUsed
+        ? data.limitedUse.maxUses - data.limitedUse.numberUsed
+        : data.limitedUse.maxUses,
+      per: resetType.value,
+    };
   } else {
-    // default
     return { value: 0, max: 0, per: null };
-  }
+  };
 };
 
 /**
@@ -371,5 +363,16 @@ export default function parseStaff(data, character) {
 
   /* save: { ability: '', dc: null } */
   // we leave that as-is
+
+  // if using dynamic items https://gitlab.com/tposney/dynamicitems/tree/master
+  // or magic items, https://gitlab.com/riccisi/foundryvtt-magic-items/ lets add some useful flags
+  // initial place holder - turn on magic item
+  weapon.flags.magicitems = {
+    enabled: data.definition.magic,
+  };
+  if (data.limitedUse) {
+    weapon.flags.magicitems.charges = data.limitedUse.maxUses;
+  };
+
   return weapon;
 }

--- a/src/parser/inventory/weapon.js
+++ b/src/parser/inventory/weapon.js
@@ -114,31 +114,23 @@ let getRange = data => {
 
 /**
  * Gets Limited uses information, if any
+ * uses: { value: 0, max: 0, per: null }
  */
 let getUses = data => {
-  // uses: { value: 0, max: 0, per: null }
-  if (data.limitedUse) {
-    if (data.limitedUse.resetType === "Consumable") {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges"
-      };
-    } else {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges"
-      };
-    }
+  if (data.limitedUse !== undefined && data.limitedUse !== null){
+    let resetType = DICTIONARY.resets.find(
+      reset => reset.id == data.limitedUse.resetType
+    );
+    return {
+      max: data.limitedUse.maxUses,
+      value: data.limitedUse.numberUsed
+        ? data.limitedUse.maxUses - data.limitedUse.numberUsed
+        : data.limitedUse.maxUses,
+      per: resetType.value,
+    };
   } else {
-    // default
     return { value: 0, max: 0, per: null };
-  }
+  };
 };
 
 /**

--- a/src/parser/inventory/wonderous.js
+++ b/src/parser/inventory/wonderous.js
@@ -2,19 +2,6 @@ import DICTIONARY from "../dictionary.js";
 import utils from "../../utils.js";
 
 /**
- * Checks the proficiency of the character with this specific weapon
- * @param {obj} data Item data
- * @param {array} proficiencies The character's proficiencies as an array of `{ name: 'PROFICIENCYNAME' }` objects
- */
-let getProficient = (data, proficiencies) => {
-  return (
-    proficiencies.find(
-      proficiency => proficiency.name === data.definition.name
-    ) !== undefined
-  );
-};
-
-/**
  * Gets the sourcebook for a subset of dndbeyond sources
  * @param {obj} data Item data
  */
@@ -75,14 +62,14 @@ let getUses = data => {
   };
 };
 
-export default function parseTool(data, character) {
+export default function parseWonderous(data, character) {
   /**
-   * MAIN parseTool
+   * MAIN parseEquipment
    */
-  let tool = {
+  let item = {
     name: data.definition.name,
-    type: "tool",
-    data: JSON.parse(utils.getTemplate("tool")),
+    type: "equipment",
+    data: JSON.parse(utils.getTemplate("equipment")),
     flags: {
       vtta: {
         dndbeyond: {
@@ -92,58 +79,77 @@ export default function parseTool(data, character) {
     }
   };
 
-  /* "ability": "int", */
-  // well. How should I know how YOU are using those tools. By pure intellect? Or with your hands?
-  tool.data.ability = "dex";
+  /* 
+    "armor": {
+    "type": "trinket",
+    "value": 10,
+    "dex": null
+  } */
+  item.data.armor = {
+    "type": "trinket",
+    "value": 10,
+    "dex": null
+  };
+
+  /* "strength": 0 */
+  item.data.strength = 0;
+
+  /* "stealth": false,*/
+  item.data.stealth = false;
+
+  /* proficient: true, */
+  item.data.proficient = true;
 
   /* description: { 
-       value: '', 
-       chat: '', 
-       unidentified: '' 
-   }, */
-  tool.data.description = {
+            value: '', 
+            chat: '', 
+            unidentified: '' 
+        }, */
+  item.data.description = {
     value: data.definition.description,
     chat: data.definition.description,
     unidentified: data.definition.type
   };
 
-  /* proficient: true, */
-  tool.data.proficient = getProficient(
-    data,
-    character.flags.vtta.dndbeyond.proficiencies
-  )
-    ? 1
-    : 0; // note: here, proficiency is not a bool, but a number (0, 0.5, 1, 2) based on not/jack of all trades/proficient/expert.
-
   /* source: '', */
-  tool.data.source = getSource(data);
+  item.data.source = getSource(data);
 
   /* quantity: 1, */
-  tool.data.quantity = data.quantity ? data.quantity : 1;
+  item.data.quantity = data.quantity ? data.quantity : 1;
 
   /* weight */
-  //tool.data.weight = data.definition.weight ? data.definition.weight : 0;
+  //item.data.weight = data.definition.weight ? data.definition.weight : 0;
   let bundleSize = data.definition.bundleSize ? data.definition.bundleSize : 1;
   let totalWeight = data.definition.weight ? data.definition.weight : 0;
-  tool.data.weight =
-    (totalWeight / bundleSize) * (tool.data.quantity / bundleSize);
+  item.data.weight =
+    (totalWeight / bundleSize) * (item.data.quantity / bundleSize);
 
   /* price */
-  tool.data.price = data.definition.cost ? data.definition.cost : 0;
+  item.data.price = data.definition.cost ? data.definition.cost : 0;
 
   /* attuned: false, */
-  tool.data.attuned = getAttuned(data);
+  item.data.attuned = getAttuned(data);
 
   /* equipped: false, */
-  tool.data.equipped = getEquipped(data);
+  item.data.equipped = getEquipped(data);
 
   /* rarity: '', */
-  tool.data.rarity = data.definition.rarity;
+  item.data.rarity = data.definition.rarity;
 
   /* identified: true, */
-  tool.data.identified = true;
+  item.data.identified = true;
 
-  tool.data.uses = getUses(data);
+  item.data.uses = getUses(data);
 
-  return tool;
+  // if using dynamic items https://gitlab.com/tposney/dynamicitems/tree/master
+  // or magic items, https://gitlab.com/riccisi/foundryvtt-magic-items/ lets add some useful flags
+  // initial place holder - turn on magic item
+  item.flags.magicitems = {
+    enabled: data.definition.magic,
+  };
+  if (data.limitedUse) {
+    item.flags.magicitems.charges = data.limitedUse.maxUses;
+  };
+
+  return item;
 }


### PR DESCRIPTION
This introduces basic support for spells from magic items.

It makes the following assumptions:
- wands, rods, wonderous items etc are imported as equipment types, and handled by a new "wonderous" item function.
- spells are imported as always available.
- they use charges on the item, and this might not always be a good match if the item has multiple spells. But better than nothing. The magic item extension at https://gitlab.com/riccisi/foundryvtt-magic-items/ does a great job at fixing/dealing with this, and compatability is a future goal of this contributor.
- only spells are imported by the item.