### PR TITLE
Support Magicitems module

### DIFF
--- a/src/character/import.js
+++ b/src/character/import.js
@@ -1,9 +1,6 @@
 import parser from "../../src/parser/index.js";
 import utils from "../utils.js";
 
-// Expected location of magicitems module
-const magicItemsPath = '../../../magicitems/magicitem.js';
-
 // a mapping of compendiums with content type
 const compendiumLookup = [
   {
@@ -24,7 +21,6 @@ export default class CharacterImport extends Application {
   constructor(options, actor) {
     super(options);
     this.actor = game.actors.entities.find(a => a.id === actor._id);
-    this.magicItems = utils.serverFileExists(magicItemsPath);
     this.result = {};
   }
   /**
@@ -140,6 +136,9 @@ export default class CharacterImport extends Application {
         utils.log("Parsing finished");
         utils.log(this.result);
 
+        // get list of loaded game modules
+        const gameModules = game.settings.get("core","moduleConfiguration");
+
         // updating the image?
         let imagePath = this.actor.img;
         if (
@@ -185,7 +184,7 @@ export default class CharacterImport extends Application {
         // the current item flags
         const compendiumSpells = await this.updateCompendium('itemSpells');
 
-        if (this.magicItems) {
+        if (gameModules["magicitems"]) {
           this.result.inventory.forEach( item => {
             if (item.flags.magicitems.spells) {
               for (let [i, spell] of Object.entries(item.flags.magicitems.spells)) {
@@ -213,7 +212,7 @@ export default class CharacterImport extends Application {
 
         // If there is no magicitems module fall back to importing the magic
         // item spells as normal spells fo the character
-        if (!this.magicItems) {
+        if (!gameModules["magicitems"]) {
           items.push(this.result.itemSpells);
           items = items.flat();
         }

--- a/src/character/import.js
+++ b/src/character/import.js
@@ -136,8 +136,8 @@ export default class CharacterImport extends Application {
         utils.log("Parsing finished");
         utils.log(this.result);
 
-        // get list of loaded game modules
-        const gameModules = game.settings.get("core","moduleConfiguration");
+        // is magicitems installed
+        const magicItemsInstalled = game.modules.get('magicitems') !== undefined;
 
         // updating the image?
         let imagePath = this.actor.img;
@@ -184,7 +184,7 @@ export default class CharacterImport extends Application {
         // the current item flags
         const compendiumSpells = await this.updateCompendium('itemSpells');
 
-        if (gameModules["magicitems"]) {
+        if (magicItemsInstalled) {
           this.result.inventory.forEach( item => {
             if (item.flags.magicitems.spells) {
               for (let [i, spell] of Object.entries(item.flags.magicitems.spells)) {
@@ -212,7 +212,7 @@ export default class CharacterImport extends Application {
 
         // If there is no magicitems module fall back to importing the magic
         // item spells as normal spells fo the character
-        if (!gameModules["magicitems"]) {
+        if (!magicItemsInstalled) {
           items.push(this.result.itemSpells);
           items = items.flat();
         }

--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -89,10 +89,13 @@ let getSpellPreparationMode = data => {
     prepMode = "innate";
   } else if ( // Warlock Mystic Arcanum are passed in as Features
       data.flags.vtta.dndbeyond.lookupName.startsWith("Mystic Arcanum")
-  ) {
+    ) {
     // these have limited uses (set with getUses())
     prepMode = "pact";
     prepared = false;
+  } else if (data.flags.vtta.dndbeyond.look === "item " && data.definition.level !== 0) {
+    prepared = false;
+    prepMode = "prepared";
   } else {
     // If spell doesn't use a spell slot and is not a cantrip, mark as always preped
     let alwaysPrepared = (!data.usesSpellSlot && data.definition.level !== 0);
@@ -118,19 +121,35 @@ let getSpellPreparationMode = data => {
  * @param {*} data Spell data
  */
 let getUses = data => {
-  if (data.limitedUse !== undefined && data.limitedUse !== null){
-    let resetType = DICTIONARY.resets.find(
-      reset => reset.id == data.limitedUse.resetType
+  let resetType = null;
+  let limitedUse = null;
+  // we check this, as things like items have useage attached to the item, not spell
+  if (data.flags.vtta.dndbeyond.limitedUse !== undefined && 
+      data.flags.vtta.dndbeyond.limitedUse !== null
+  ){
+    limitedUse = data.flags.vtta.dndbeyond.limitedUse
+    resetType = DICTIONARY.resets.find(
+      reset => reset.id == limitedUse.resetType
     );
+
+  } else if (data.limitedUse !== undefined && data.limitedUse !== null){
+    limitedUse = data.limitedUse
+    resetType = DICTIONARY.resets.find(
+      reset => reset.id == limitedUse.resetType
+    );
+  };
+  
+  if (resetType !== null) {
     return {
-      value: data.limitedUse.maxUses - data.limitedUse.numberUsed,
-      max: data.limitedUse.maxUses,
+      value: limitedUse.numberUsed
+        ? limitedUse.maxUses - limitedUse.numberUsed
+        : limitedUse.maxUses,
+      max: limitedUse.maxUses,
       per: resetType.value,
     };
   } else {
     return {};
   };
-  
 };
 
 /**
@@ -465,6 +484,7 @@ let getLookups = (character) => {
     feat: [],
     class: [],
     classFeature: [],
+    item: [],
   };
   character.race.racialTraits.forEach( trait => {
     lookups.race.push({
@@ -510,6 +530,18 @@ let getLookups = (character) => {
       id: trait.definition.id,
       name: trait.definition.name,
       componentId: trait.componentId,
+    })
+  });
+
+  character.inventory.forEach( trait => {
+    lookups.item.push({
+      id: trait.definition.id,
+      name: trait.definition.name,
+      limitedUse: trait.limitedUse,
+      equipped: trait.equipped,
+      isAttuned: trait.isAttuned,
+      canAttune: trait.definition.canAttune,
+      canEquip: trait.definition.canEquip,
     })
   });
 
@@ -774,5 +806,50 @@ export default function parseSpells(ddb, character) {
     items.push(parseSpell(spell, character));
   });
 
+  // feat spells are handled slightly differently
+  ddb.character.spells.item.forEach(spell => {
+    let itemInfo = lookups.item.find(
+      it => it.id === spell.componentId
+    );
+
+    //lets see if we have the item equipped/attuned to actually grant anythings
+    if (
+      (!itemInfo.canEquip && !itemInfo.canAttune) || // if item just gives a thing
+      (itemInfo.isAttuned) || // if it is attuned (assume equipped)
+      (!itemInfo.canAttune && itemInfo.equipped) // can't attune but is equipped
+    ) {
+      // for item spells the spell dc is often on the item spell
+      let spellDC = 8;
+      if (spell.overrideSaveDc) {
+        spellDC = spell.overrideSaveDc;
+      } else if (spell.spellCastingAbilityId) {
+        let spellCastingAbility = convertSpellCastingAbilityId(
+          spell.spellCastingAbilityId
+        );
+    
+        let abilityModifier = utils.calculateModifier(
+          character.data.abilities[spellCastingAbility].value
+        );
+        spellDC = 8 + proficiencyModifier + abilityModifier;
+      } else {
+        spellDC = null;
+      }; 
+
+      // add some data for the parsing of the spells into the data structure
+      spell.flags = {
+        vtta: {
+          dndbeyond: {
+            lookup: "item",
+            lookupName: itemInfo.name,
+            lookupId: itemInfo.id,
+            level: spell.castAtLevel,
+            dc: spellDC,
+            limitedUse: itemInfo.limitedUse,
+          }
+        }
+      };
+      items.push(parseSpell(spell, character));
+    };
+  });
   return items;
 }

--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -711,7 +711,6 @@ export default function parseSpells(ddb, character) {
 
   // Race spells are handled slightly differently
   ddb.character.spells.race.forEach(spell => {
-    let spellCastingAbility = undefined;
     // for race spells the spell spellCastingAbilityId is on the spell
     // if there is no ability on spell, we default to wis
     let spellCastingAbility = "wis";

--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -672,8 +672,8 @@ export default function parseSpells(ddb, character) {
 
   // Parse any spells granted by class features, such as Barbarian Totem
   ddb.character.spells.class.forEach(spell => {
-    let spellCastingAbility = undefined;
     // If the spell has an ability attached, use that
+    let spellCastingAbility = undefined;
     if (hasSpellCastingAbility(spell.spellCastingAbilityId)) {
       spellCastingAbility = convertSpellCastingAbilityId(
         spell.spellCastingAbilityId
@@ -712,15 +712,14 @@ export default function parseSpells(ddb, character) {
   // Race spells are handled slightly differently
   ddb.character.spells.race.forEach(spell => {
     let spellCastingAbility = undefined;
-    // If the spell has an ability attached, use that
+    // for race spells the spell spellCastingAbilityId is on the spell
+    // if there is no ability on spell, we default to wis
+    let spellCastingAbility = "wis";
     if (hasSpellCastingAbility(spell.spellCastingAbilityId)) {
       spellCastingAbility = convertSpellCastingAbilityId(
         spell.spellCastingAbilityId
       );
-    } else {
-      // if there is no ability on spell, we default to wis
-      spellCastingAbility = "wis";
-    }
+    };
 
     let abilityModifier = utils.calculateModifier(
       character.data.abilities[spellCastingAbility].value
@@ -760,16 +759,14 @@ export default function parseSpells(ddb, character) {
 
   // feat spells are handled slightly differently
   ddb.character.spells.feat.forEach(spell => {
-    let spellCastingAbility = undefined;
     // If the spell has an ability attached, use that
+    // if there is no ability on spell, we default to wis
+    let spellCastingAbility = "wis";
     if (hasSpellCastingAbility(spell.spellCastingAbilityId)) {
       spellCastingAbility = convertSpellCastingAbilityId(
         spell.spellCastingAbilityId
       );
-    } else {
-      // if there is no ability on spell, we default to wis
-      spellCastingAbility = "wis";
-    }
+    };
 
     let abilityModifier = utils.calculateModifier(
       character.data.abilities[spellCastingAbility].value
@@ -823,9 +820,14 @@ export default function parseSpells(ddb, character) {
       if (spell.overrideSaveDc) {
         spellDC = spell.overrideSaveDc;
       } else if (spell.spellCastingAbilityId) {
-        let spellCastingAbility = convertSpellCastingAbilityId(
-          spell.spellCastingAbilityId
-        );
+        // If the spell has an ability attached, use that
+        // if there is no ability on spell, we default to wis
+        let spellCastingAbility = "wis";
+        if (hasSpellCastingAbility(spell.spellCastingAbilityId)) {
+          spellCastingAbility = convertSpellCastingAbilityId(
+            spell.spellCastingAbilityId
+          );
+        };
     
         let abilityModifier = utils.calculateModifier(
           character.data.abilities[spellCastingAbility].value

--- a/src/parser/dictionary.js
+++ b/src/parser/dictionary.js
@@ -1,4 +1,26 @@
 const DICTIONARY = {
+    magicitems: {
+        rechargeUnits: [
+            { id: 1, value: 'r4' },
+            { id: 'ShortRest', value: 'r4' },
+            { id: 2, value: 'r5' },
+            { id: 'LongRest', value: 'r5' },
+            { id: 'Dawn', value: 'r2' },
+            { id: 'Consumable', value: '' },
+            { id: 'Other', value: '' },
+            { id: 'Daily', value: 'r1' },
+            { id: 'sr', value: 'r4' },
+            { id: 'lr', value: 'r5' },
+        ],
+        nums: [
+            { id: 'once', value: 1 },
+            { id: 'twice', value: 2 },
+            { id: 'thrice', value: 3 },
+            { id: 'one', value: 1 },
+            { id: 'two', value: 2 },
+            { id: 'thee', value: 3 },
+        ]
+    },
     resets: [
         { id: 1, value: 'sr' },
         { id: 'ShortRest', value: 'sr' },

--- a/src/parser/dictionary.js
+++ b/src/parser/dictionary.js
@@ -6,6 +6,7 @@ const DICTIONARY = {
         { id: 'LongRest', value: 'lr' },
         { id: 'Dawn', value: 'day' },
         { id: 'Consumable', value: 'charges' },
+        { id: 'Other', value: 'charges' },
     ],
     character: {
         abilities: [

--- a/src/parser/index.js
+++ b/src/parser/index.js
@@ -1,8 +1,7 @@
 import getCharacter from "./character/index.js";
 import getFeatures from "./character/features.js";
 import getClasses from "./character/classes.js";
-
-import getSpells from "./character/spells.js";
+import {default as getSpells, parseItemSpells as getItemSpells} from "./character/spells.js";
 import getInventory from "./inventory/index.js";
 import getActions from "./character/actions.js";
 
@@ -10,9 +9,10 @@ let parseJson = ddb => {
   let character = getCharacter(ddb);
   let features = getFeatures(ddb, character);
   let classes = getClasses(ddb, character);
-  let inventory = getInventory(ddb, character);
   let spells = getSpells(ddb, character);
   let actions = getActions(ddb, character);
+  let itemSpells = getItemSpells(ddb, character);
+  let inventory = getInventory(ddb, character, itemSpells);
 
   return {
     character: character,
@@ -20,7 +20,8 @@ let parseJson = ddb => {
     classes: classes,
     inventory: inventory,
     spells: spells,
-    actions: actions
+    actions: actions,
+    itemSpells: itemSpells,
   };
 };
 

--- a/src/parser/inventory/ammunition.js
+++ b/src/parser/inventory/ammunition.js
@@ -114,31 +114,24 @@ let getRange = data => {
 
 /**
  * Gets Limited uses information, if any
+ * uses: { value: 0, max: 0, per: null }
  */
 let getUses = data => {
-  // uses: { value: 0, max: 0, per: null }
-  if (data.limitedUse) {
-    if (data.limitedUse.resetType === "Consumable") {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges"
-      };
-    } else {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges"
-      };
-    }
+  if (data.limitedUse !== undefined && data.limitedUse !== null){
+    let resetType = DICTIONARY.resets.find(
+      reset => reset.id == data.limitedUse.resetType
+    );
+    return {
+      max: data.limitedUse.maxUses,
+      value: data.limitedUse.numberUsed
+        ? data.limitedUse.maxUses - data.limitedUse.numberUsed
+        : data.limitedUse.maxUses,
+      per: resetType.value,
+      description: data.limitedUse.resetTypeDescription,
+    };
   } else {
-    // default
     return { value: 0, max: 0, per: null };
-  }
+  };
 };
 
 /**
@@ -327,7 +320,7 @@ export default function parseWeapon(data, character) {
   weapon.data.range = getRange(data);
 
   /* uses: { value: 0, max: 0, per: null }, */
-  weapon.data.uses = getUses(data);
+  //weapon.data.uses = getUses(data);
 
   /* ability: null, */
   weapon.data.ability = getAbility(

--- a/src/parser/inventory/armor.js
+++ b/src/parser/inventory/armor.js
@@ -111,7 +111,28 @@ let getEquipped = data => {
     return data.equipped;
 };
 
-export default function parseEquipment(data, character) {
+/**
+ * Gets Limited uses information, if any
+ * uses: { value: 0, max: 0, per: null }
+ */
+let getUses = data => {
+  if (data.limitedUse !== undefined && data.limitedUse !== null){
+    let resetType = DICTIONARY.resets.find(
+      reset => reset.id == data.limitedUse.resetType
+    );
+    return {
+      max: data.limitedUse.maxUses,
+      value: data.limitedUse.numberUsed
+        ? data.limitedUse.maxUses - data.limitedUse.numberUsed
+        : data.limitedUse.maxUses,
+      per: resetType.value,
+    };
+  } else {
+    return { value: 0, max: 0, per: null };
+  };
+};
+
+export default function parseArmor(data, character) {
   /**
    * MAIN parseEquipment
    */
@@ -186,6 +207,8 @@ export default function parseEquipment(data, character) {
 
   /* identified: true, */
   armor.data.identified = true;
+
+  armor.data.uses = getUses(data);
 
   return armor;
 }

--- a/src/parser/inventory/armor.js
+++ b/src/parser/inventory/armor.js
@@ -126,6 +126,7 @@ let getUses = data => {
         ? data.limitedUse.maxUses - data.limitedUse.numberUsed
         : data.limitedUse.maxUses,
       per: resetType.value,
+      description: data.limitedUse.resetTypeDescription,
     };
   } else {
     return { value: 0, max: 0, per: null };
@@ -208,7 +209,7 @@ export default function parseArmor(data, character) {
   /* identified: true, */
   armor.data.identified = true;
 
-  armor.data.uses = getUses(data);
+  //armor.data.uses = getUses(data);
 
   return armor;
 }

--- a/src/parser/inventory/index.js
+++ b/src/parser/inventory/index.js
@@ -5,7 +5,10 @@ import parseAmmunition from './ammunition.js';
 import parseStaff from './staves.js';
 
 // type: armor
-import parseEquipment from './equipment.js';
+import parseArmor from './armor.js';
+
+// tyoe: wonderous item
+import parseWonderous from './wonderous.js';
 
 // type: consumables
 import parsePotion from './potion.js';
@@ -29,15 +32,18 @@ let parseItem = (data, character) => {
           return parseWeapon(data, character);
         }
         break;
-
       case 'Armor':
-        return parseEquipment(data, character);
+        return parseArmor(data, character);
         break;
-
+      case 'Wondrous item':
+      case 'Ring':
+      case 'Wand':
+      case 'Rod':
+        return parseWonderous(data,character);
+        break
       case 'Staff':
         return parseStaff(data, character);
         break;
-
       case 'Potion':
         return parsePotion(data, character);
         break;

--- a/src/parser/inventory/index.js
+++ b/src/parser/inventory/index.js
@@ -21,6 +21,9 @@ import parseTool from './tool.js';
 import parseLoot from './loot.js';
 import utils from '../../utils.js';
 
+// magicitems support
+import parseMagicItem from './magicify.js';
+
 let parseItem = (data, character) => {
   // is it a weapon?
   if (data.definition.filterType) {
@@ -71,7 +74,7 @@ let parseItem = (data, character) => {
   return {};
 };
 
-export default function getInventory(ddb, character) {
+export default function getInventory(ddb, character, itemSpells) {
   let items = [];
   // first, check custom name, price or weight
   ddb.character.characterValues.forEach(cv => {
@@ -89,9 +92,11 @@ export default function getInventory(ddb, character) {
   for (let entry of ddb.character.inventory) {
     var item = Object.assign({}, parseItem(entry, character));
     if (item) {
+      let magicItem = parseMagicItem(entry, character, item, itemSpells);
+      item.flags.magicitems = magicItem;
       items.push(item);
     }
-  }
+  };
 
   // character.customItems missing
 

--- a/src/parser/inventory/magicify.js
+++ b/src/parser/inventory/magicify.js
@@ -1,0 +1,212 @@
+/**
+Attempts to parse information from ddb about items to build a magicitems
+compatible set of metadata.
+
+https://gitlab.com/riccisi/foundryvtt-magic-items/
+
+ * Wand of Entangle Target example
+ *
+  flags": {
+  "magicitems": {
+      "enabled": true,
+      "charges": "7",
+      "chargeType": "c1",
+      "destroy": true,
+      "destroyCheck": "d1",
+      "rechargeable": true,
+      "recharge": "1d6+1",
+      "rechargeType": "t2",
+      "rechargeUnit": "r2",
+      "spells": {
+          "0": {
+              "id": "af8QUpphSZMoi2yb",
+              "name": "Entangle",
+              "pack": "world.spellsdndbeyond",
+              "img": "iconizer/Spell_Nature_StrangleVines.png",
+              "baseLevel": "1",
+              "level": "1",
+              "consumption": "1",
+              "upcast": "1",
+              "upcastCost": "1"
+          }
+      }
+  }
+ * 
+ * 
+ **/
+import DICTIONARY from "../dictionary.js";
+import utils from "../../utils.js";
+
+// Expected location of magicitems module
+const magicItemsPath = '../../../../magicitems/magicitem.js';
+
+const MAGICITEMS = {};
+MAGICITEMS.DAILY = 'r1';
+MAGICITEMS.SHORT_REST = 'r4';
+MAGICITEMS.LONG_REST = 'r5';
+MAGICITEMS.CHARGE_TYPE_WHOLE_ITEM = "c1";
+MAGICITEMS.CHARGE_TYPE_PER_SPELL = "c2";
+MAGICITEMS.NUMERIC_RECHARGE = 't1';
+MAGICITEMS.FORMULA_RECHARGE = 't2';
+MAGICITEMS.DestroyCheckAlways = "d1";
+MAGICITEMS.DestroyCheck1D20 = "d2";
+
+
+function getRechargeFormula(description, maxCharges) {
+  if (description === "") {
+    return maxCharges;
+  };
+
+  let chargeMatchFormula = /regains (?<formula>\dd\d* \+ \d) expended charges/i;
+  let chargeMatchFixed = /regains (?<formula>\d*) /i;
+  let chargeMatchLastDitch = /(?<formula>\dd\d* \+ \d)/i;
+  let chargeNextDawn = /can't be used this way again until the next/i;
+
+  let match = chargeMatchFormula.exec(description);
+
+  if (match && match.groups.formula) {
+    match = match.groups.formula;
+  } else if (match = chargeMatchFixed.exec(description)) {
+    match = match.groups.formula;
+  } else if (match = chargeMatchLastDitch.exec(description)) {
+    match = match.groups.formula;
+  } else if (description.search(chargeNextDawn) !== -1) {
+    match = maxCharges;
+  };
+
+  return match;
+};
+
+function getPerSpells(description) {
+  if (description === "") {
+    return false;
+  };
+
+  let perSpell = /each (?<num>[A-z]*|\n*) per/i;
+  let match = perSpell.exec(description);
+
+  if (match && match.groups.num) {
+    match = DICTIONARY.magicitems.nums.find(
+      num => num.id == match.groups.num
+    ).value;
+  } else {
+    match = null;
+  };
+  return match;
+};
+
+function checkDestroy(description) {
+  let destroy = /expend the (?<item>.*) last charge/i;
+  let match = destroy.exec(description);
+  if (match && match.groups.item) {
+    return true;
+  } else {
+    return false;
+  };
+};
+
+function checkD20Destroy(description) {
+  let destroy = /roll a (?<d20>d20).*destroyed/i;
+  let match = destroy.exec(description);
+  if (match && match.groups.d20) {
+    return MAGICITEMS.DestroyCheck1D20;
+  } else {
+    return MAGICITEMS.DestroyCheckAlways;
+  };
+};
+
+// returns the default magicitem flags
+function buildMagicItemSpell(chargeType,itemSpell) {
+  let consumption = (chargeType == MAGICITEMS.CHARGE_TYPE_WHOLE_ITEM) ? 1 : itemSpell.data.level;
+  return {
+    id: "",
+    name: itemSpell.name,
+    img: "",
+    pack: "",
+    baseLevel: itemSpell.data.level,
+    level: itemSpell.data.level,
+    consumption: consumption,
+    upcast: itemSpell.data.level,
+    upcastCost: 1
+  };
+};
+
+function getItemSpells(itemId, chargeType, itemSpells) {
+  let spells = {};
+
+  for(let spellIndex=0, i=0; i<itemSpells.length; i++) {
+    if (itemSpells[i].flags.vtta.dndbeyond.lookupId === itemId) {
+      spells[spellIndex] = buildMagicItemSpell(chargeType,itemSpells[i]);
+      spellIndex++;
+    };
+  };
+
+  return spells;
+}
+
+function createDefaultItem() {
+  return {
+    enabled: true,
+    charges: 0,
+    chargeType: MAGICITEMS.CHARGE_TYPE_WHOLE_ITEM, // c1 charge whole item, c2 charge per spells
+    rechargeable: false,
+    recharge: 0, // recharge amount/formula
+    rechargeType: MAGICITEMS.FORMULA_RECHARGE, //t1 fixed amount, t2 formula
+    rechargeUnit: '', // r1 daily, r2 dawn, r3 sunset, r4vshort rest, r5 long rest
+    destroy: false, // destroy on depleted? 
+    destroyCheck: MAGICITEMS.DestroyCheckAlways, // d1 always, 1d20
+    spells: {},
+    feats: {},
+    tables: {}
+  };
+};
+
+export default function parseMagicItem(data, character, item, itemSpells) {
+  // this checks to see if the magicitems module is present
+  // https://gitlab.com/riccisi/foundryvtt-magic-items/
+  // if so it loads and attempts to get as much data as possible for it
+
+  if (data.definition.magic && utils.serverFileExists(magicItemsPath)) {
+    // default magicitem data
+    let magicItem = createDefaultItem();
+
+    if (data.limitedUse) {
+      // if the item is x per spell
+      let perSpells = getPerSpells(data.limitedUse.resetTypeDescription);
+      if (perSpells) {
+        magicItem.charges = perSpells;
+        magicItem.chargeType = MAGICITEMS.CHARGE_TYPE_WHOLE_ITEM;
+        magicItem.recharge = perSpells;
+        magicItem.rechargeUnit = MAGICITEMS.DAILY;
+        magicItem.rechargeable = true;
+        magicItem.rechargeType = MAGICITEMS.NUMERIC_RECHARGE;
+      } else {
+        magicItem.charges = data.limitedUse.maxUses;
+        magicItem.chargeType = MAGICITEMS.CHARGE_TYPE_PER_SPELL;
+
+        magicItem.recharge = getRechargeFormula(
+          data.limitedUse.resetTypeDescription, magicItem.charges
+        );
+
+        if (data.limitedUse.resetType) {
+          magicItem.rechargeUnit = DICTIONARY.magicitems.rechargeUnits.find(
+            reset => reset.id == data.limitedUse.resetType
+          ).value;
+        };
+        magicItem.rechargeable = true;
+      };
+
+      magicItem.destroy = checkDestroy(data.limitedUse.resetTypeDescription);
+      magicItem.destroyCheck = checkD20Destroy(data.limitedUse.resetTypeDescription);
+    };
+
+    magicItem.spells = getItemSpells(data.definition.id, magicItem.chargeType, itemSpells);
+
+    return magicItem;
+    
+  } else {
+    return {
+      enabled: false
+    };
+  };
+};

--- a/src/parser/inventory/magicify.js
+++ b/src/parser/inventory/magicify.js
@@ -35,10 +35,6 @@ https://gitlab.com/riccisi/foundryvtt-magic-items/
  * 
  **/
 import DICTIONARY from "../dictionary.js";
-import utils from "../../utils.js";
-
-// Expected location of magicitems module
-const magicItemsPath = '../../../../magicitems/magicitem.js';
 
 const MAGICITEMS = {};
 MAGICITEMS.DAILY = 'r1';
@@ -162,11 +158,10 @@ function createDefaultItem() {
 };
 
 export default function parseMagicItem(data, character, item, itemSpells) {
-  // this checks to see if the magicitems module is present
+  // this builds metadata for the magicitems module to use
   // https://gitlab.com/riccisi/foundryvtt-magic-items/
-  // if so it loads and attempts to get as much data as possible for it
 
-  if (data.definition.magic && utils.serverFileExists(magicItemsPath)) {
+  if (data.definition.magic) {
     // default magicitem data
     let magicItem = createDefaultItem();
 

--- a/src/parser/inventory/potion.js
+++ b/src/parser/inventory/potion.js
@@ -3,35 +3,26 @@ import utils from "../../utils.js";
 
 /**
  * Gets Limited uses information, if any
+ * uses: { value: 0, max: 0, per: null, autoUse: false, autoDestroy: false };
  */
 let getUses = data => {
-  // uses: { value: 0, max: 0, per: null }
-  if (data.limitedUse) {
-    if (data.limitedUse.resetType === "Consumable") {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges",
-        autoUse: false,
-        autoDestroy: true
-      };
-    } else {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges",
-        autoUse: false,
-        autoDestroy: true
-      };
-    }
+  if (data.limitedUse !== undefined && data.limitedUse !== null){
+    let resetType = DICTIONARY.resets.find(
+      reset => reset.id == data.limitedUse.resetType
+    );
+    return {
+      max: data.limitedUse.maxUses,
+      value: data.limitedUse.numberUsed
+        ? data.limitedUse.maxUses - data.limitedUse.numberUsed
+        : data.limitedUse.maxUses,
+      per: resetType.value,
+      autoUse: false,
+      autoDestroy: true,
+    };
   } else {
-    // default
     return { value: 0, max: 0, per: null, autoUse: false, autoDestroy: false };
-  }
+  };
+  
 };
 
 /**
@@ -198,6 +189,8 @@ export default function parsePotion(data, character) {
   consumable.data.actionType = getActionType(data);
 
   consumable.data.damage = getDamage(data, getActionType(data));
+
+  consumable.data.uses = getUses(data);
 
   return consumable;
 }

--- a/src/parser/inventory/scroll.js
+++ b/src/parser/inventory/scroll.js
@@ -7,27 +7,15 @@ import utils from "../../utils.js";
 let getUses = data => {
   // uses: { value: 0, max: 0, per: null }
   if (data.limitedUse) {
-    if (data.limitedUse.resetType === "Consumable") {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges",
-        autoUse: false,
-        autoDestroy: false
-      };
-    } else {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges",
-        autoUse: false,
-        autoDestroy: false
-      };
-    }
+    return {
+      max: data.limitedUse.maxUses,
+      value: data.limitedUse.numberUsed
+        ? data.limitedUse.maxUses - data.limitedUse.numberUsed
+        : data.limitedUse.maxUses,
+      per: "charges",
+      autoUse: false,
+      autoDestroy: true,
+    };
   } else {
     // default
     return { value: 0, max: 0, per: null, autoUse: false, autoDestroy: false };

--- a/src/parser/inventory/staves.js
+++ b/src/parser/inventory/staves.js
@@ -127,6 +127,7 @@ let getUses = data => {
         ? data.limitedUse.maxUses - data.limitedUse.numberUsed
         : data.limitedUse.maxUses,
       per: resetType.value,
+      description: data.limitedUse.resetTypeDescription,
     };
   } else {
     return { value: 0, max: 0, per: null };
@@ -332,7 +333,7 @@ export default function parseStaff(data, character) {
   weapon.data.range = getRange(data);
 
   /* uses: { value: 0, max: 0, per: null }, */
-  weapon.data.uses = getUses(data);
+  //weapon.data.uses = getUses(data);
 
   /* ability: null, */
   weapon.data.ability = getAbility(
@@ -363,16 +364,6 @@ export default function parseStaff(data, character) {
 
   /* save: { ability: '', dc: null } */
   // we leave that as-is
-
-  // if using dynamic items https://gitlab.com/tposney/dynamicitems/tree/master
-  // or magic items, https://gitlab.com/riccisi/foundryvtt-magic-items/ lets add some useful flags
-  // initial place holder - turn on magic item
-  weapon.flags.magicitems = {
-    enabled: data.definition.magic,
-  };
-  if (data.limitedUse) {
-    weapon.flags.magicitems.charges = data.limitedUse.maxUses;
-  };
 
   return weapon;
 }

--- a/src/parser/inventory/staves.js
+++ b/src/parser/inventory/staves.js
@@ -114,31 +114,23 @@ let getRange = data => {
 
 /**
  * Gets Limited uses information, if any
+ * uses: { value: 0, max: 0, per: null }
  */
 let getUses = data => {
-  // uses: { value: 0, max: 0, per: null }
-  if (data.limitedUse) {
-    if (data.limitedUse.resetType === "Consumable") {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges"
-      };
-    } else {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges"
-      };
-    }
+  if (data.limitedUse !== undefined && data.limitedUse !== null){
+    let resetType = DICTIONARY.resets.find(
+      reset => reset.id == data.limitedUse.resetType
+    );
+    return {
+      max: data.limitedUse.maxUses,
+      value: data.limitedUse.numberUsed
+        ? data.limitedUse.maxUses - data.limitedUse.numberUsed
+        : data.limitedUse.maxUses,
+      per: resetType.value,
+    };
   } else {
-    // default
     return { value: 0, max: 0, per: null };
-  }
+  };
 };
 
 /**
@@ -371,5 +363,16 @@ export default function parseStaff(data, character) {
 
   /* save: { ability: '', dc: null } */
   // we leave that as-is
+
+  // if using dynamic items https://gitlab.com/tposney/dynamicitems/tree/master
+  // or magic items, https://gitlab.com/riccisi/foundryvtt-magic-items/ lets add some useful flags
+  // initial place holder - turn on magic item
+  weapon.flags.magicitems = {
+    enabled: data.definition.magic,
+  };
+  if (data.limitedUse) {
+    weapon.flags.magicitems.charges = data.limitedUse.maxUses;
+  };
+
   return weapon;
 }

--- a/src/parser/inventory/weapon.js
+++ b/src/parser/inventory/weapon.js
@@ -114,31 +114,23 @@ let getRange = data => {
 
 /**
  * Gets Limited uses information, if any
+ * uses: { value: 0, max: 0, per: null }
  */
 let getUses = data => {
-  // uses: { value: 0, max: 0, per: null }
-  if (data.limitedUse) {
-    if (data.limitedUse.resetType === "Consumable") {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges"
-      };
-    } else {
-      return {
-        max: data.limitedUse.maxUses,
-        value: data.limitedUse.numberUsed
-          ? data.limitedUse.maxUses - data.limitedUse.numberUsed
-          : data.limitedUse.maxUses,
-        per: "charges"
-      };
-    }
+  if (data.limitedUse !== undefined && data.limitedUse !== null){
+    let resetType = DICTIONARY.resets.find(
+      reset => reset.id == data.limitedUse.resetType
+    );
+    return {
+      max: data.limitedUse.maxUses,
+      value: data.limitedUse.numberUsed
+        ? data.limitedUse.maxUses - data.limitedUse.numberUsed
+        : data.limitedUse.maxUses,
+      per: resetType.value,
+    };
   } else {
-    // default
     return { value: 0, max: 0, per: null };
-  }
+  };
 };
 
 /**

--- a/src/parser/inventory/weapon.js
+++ b/src/parser/inventory/weapon.js
@@ -127,6 +127,7 @@ let getUses = data => {
         ? data.limitedUse.maxUses - data.limitedUse.numberUsed
         : data.limitedUse.maxUses,
       per: resetType.value,
+      description: data.limitedUse.resetTypeDescription,
     };
   } else {
     return { value: 0, max: 0, per: null };
@@ -336,7 +337,7 @@ export default function parseWeapon(data, character) {
   weapon.data.range = getRange(data);
 
   /* uses: { value: 0, max: 0, per: null }, */
-  weapon.data.uses = getUses(data);
+  //weapon.data.uses = getUses(data);
 
   /* ability: null, */
   weapon.data.ability = getAbility(

--- a/src/parser/inventory/wonderous.js
+++ b/src/parser/inventory/wonderous.js
@@ -2,19 +2,6 @@ import DICTIONARY from "../dictionary.js";
 import utils from "../../utils.js";
 
 /**
- * Checks the proficiency of the character with this specific weapon
- * @param {obj} data Item data
- * @param {array} proficiencies The character's proficiencies as an array of `{ name: 'PROFICIENCYNAME' }` objects
- */
-let getProficient = (data, proficiencies) => {
-  return (
-    proficiencies.find(
-      proficiency => proficiency.name === data.definition.name
-    ) !== undefined
-  );
-};
-
-/**
  * Gets the sourcebook for a subset of dndbeyond sources
  * @param {obj} data Item data
  */
@@ -75,14 +62,14 @@ let getUses = data => {
   };
 };
 
-export default function parseTool(data, character) {
+export default function parseWonderous(data, character) {
   /**
-   * MAIN parseTool
+   * MAIN parseEquipment
    */
-  let tool = {
+  let item = {
     name: data.definition.name,
-    type: "tool",
-    data: JSON.parse(utils.getTemplate("tool")),
+    type: "equipment",
+    data: JSON.parse(utils.getTemplate("equipment")),
     flags: {
       vtta: {
         dndbeyond: {
@@ -92,58 +79,77 @@ export default function parseTool(data, character) {
     }
   };
 
-  /* "ability": "int", */
-  // well. How should I know how YOU are using those tools. By pure intellect? Or with your hands?
-  tool.data.ability = "dex";
+  /* 
+    "armor": {
+    "type": "trinket",
+    "value": 10,
+    "dex": null
+  } */
+  item.data.armor = {
+    "type": "trinket",
+    "value": 10,
+    "dex": null
+  };
+
+  /* "strength": 0 */
+  item.data.strength = 0;
+
+  /* "stealth": false,*/
+  item.data.stealth = false;
+
+  /* proficient: true, */
+  item.data.proficient = true;
 
   /* description: { 
-       value: '', 
-       chat: '', 
-       unidentified: '' 
-   }, */
-  tool.data.description = {
+            value: '', 
+            chat: '', 
+            unidentified: '' 
+        }, */
+  item.data.description = {
     value: data.definition.description,
     chat: data.definition.description,
     unidentified: data.definition.type
   };
 
-  /* proficient: true, */
-  tool.data.proficient = getProficient(
-    data,
-    character.flags.vtta.dndbeyond.proficiencies
-  )
-    ? 1
-    : 0; // note: here, proficiency is not a bool, but a number (0, 0.5, 1, 2) based on not/jack of all trades/proficient/expert.
-
   /* source: '', */
-  tool.data.source = getSource(data);
+  item.data.source = getSource(data);
 
   /* quantity: 1, */
-  tool.data.quantity = data.quantity ? data.quantity : 1;
+  item.data.quantity = data.quantity ? data.quantity : 1;
 
   /* weight */
-  //tool.data.weight = data.definition.weight ? data.definition.weight : 0;
+  //item.data.weight = data.definition.weight ? data.definition.weight : 0;
   let bundleSize = data.definition.bundleSize ? data.definition.bundleSize : 1;
   let totalWeight = data.definition.weight ? data.definition.weight : 0;
-  tool.data.weight =
-    (totalWeight / bundleSize) * (tool.data.quantity / bundleSize);
+  item.data.weight =
+    (totalWeight / bundleSize) * (item.data.quantity / bundleSize);
 
   /* price */
-  tool.data.price = data.definition.cost ? data.definition.cost : 0;
+  item.data.price = data.definition.cost ? data.definition.cost : 0;
 
   /* attuned: false, */
-  tool.data.attuned = getAttuned(data);
+  item.data.attuned = getAttuned(data);
 
   /* equipped: false, */
-  tool.data.equipped = getEquipped(data);
+  item.data.equipped = getEquipped(data);
 
   /* rarity: '', */
-  tool.data.rarity = data.definition.rarity;
+  item.data.rarity = data.definition.rarity;
 
   /* identified: true, */
-  tool.data.identified = true;
+  item.data.identified = true;
 
-  tool.data.uses = getUses(data);
+  item.data.uses = getUses(data);
 
-  return tool;
+  // if using dynamic items https://gitlab.com/tposney/dynamicitems/tree/master
+  // or magic items, https://gitlab.com/riccisi/foundryvtt-magic-items/ lets add some useful flags
+  // initial place holder - turn on magic item
+  item.flags.magicitems = {
+    enabled: data.definition.magic,
+  };
+  if (data.limitedUse) {
+    item.flags.magicitems.charges = data.limitedUse.maxUses;
+  };
+
+  return item;
 }

--- a/src/parser/inventory/wonderous.js
+++ b/src/parser/inventory/wonderous.js
@@ -56,6 +56,7 @@ let getUses = data => {
         ? data.limitedUse.maxUses - data.limitedUse.numberUsed
         : data.limitedUse.maxUses,
       per: resetType.value,
+      description: data.limitedUse.resetTypeDescription,
     };
   } else {
     return { value: 0, max: 0, per: null };
@@ -140,16 +141,6 @@ export default function parseWonderous(data, character) {
   item.data.identified = true;
 
   item.data.uses = getUses(data);
-
-  // if using dynamic items https://gitlab.com/tposney/dynamicitems/tree/master
-  // or magic items, https://gitlab.com/riccisi/foundryvtt-magic-items/ lets add some useful flags
-  // initial place holder - turn on magic item
-  item.flags.magicitems = {
-    enabled: data.definition.magic,
-  };
-  if (data.limitedUse) {
-    item.flags.magicitems.charges = data.limitedUse.maxUses;
-  };
 
   return item;
 }


### PR DESCRIPTION
Extends https://github.com/VTTAssets/vtta-dndbeyond/pull/31

- Wands, rods, wondrous items etc are imported as equipment types.
- start on using the magic item extension for providing these spells.
- spells are imported as always available.
- item spells have the item name in there name.
- they use charges on the item, and this might not always be a good match if the item has multiple spells. But better than nothing. 
- *However* if the magicitems module https://gitlab.com/riccisi/foundryvtt-magic-items/ is installed.
- Stop fetching uses on weapons etc as this limits their use as weapons.
- Break up of a couple of big pieces of functionality into class methods
- Filter to check for magicitem module and import metadata if it exists.

Resolves #5 


Example without magicitems module:
![](https://cdn.discordapp.com/attachments/684421914956922946/696303872695861309/Selection_223.png)

With magicitems module:
![](https://cdn.discordapp.com/attachments/684421914956922946/696304038345441290/Selection_221.png)
![](https://cdn.discordapp.com/attachments/684421914956922946/696304006292701184/Selection_222.png)