### PR TITLE
Fix Condition dectection

### DIFF
--- a/src/parser/character/index.js
+++ b/src/parser/character/index.js
@@ -841,128 +841,80 @@ let getLanguages = data => {
   };
 };
 
-let getDamageImmunities = data => {
-  let damageTypes = DICTIONARY.character.damageTypes
-    .filter(type => type.kind === "immunity" && type.type === 2)
+let getGenericConditionAffect = (data, condition, typeId) => {
+  const damageTypes = DICTIONARY.character.damageTypes
+    .filter(type => type.kind === condition && type.type === typeId)
     .map(type => type.value);
 
-  let result = data.character.modifiers.race
-    .filter(
-      modifier =>
-        modifier.type === "immunity" && damageTypes.includes(modifier.subType)
+  let result = [
+    data.character.modifiers.class,
+    data.character.modifiers.race,
+    data.character.modifiers.background,
+    data.character.modifiers.item,
+    data.character.modifiers.feat,
+  ]
+    .flat()
+    .filter(modifier =>
+      modifier.type === condition &&
+      modifier.isGranted &&
+      damageTypes.includes(modifier.subType)
     )
-    .map(immunity => immunity.subType);
+    .map(modifier => {
+      const entry = DICTIONARY.character.damageTypes.find(
+        type => (
+          type.type === typeId &&
+          type.kind === modifier.type &&
+          type.value === modifier.subType
+        )
+      );
+      return entry ? entry.vttaValue || entry.value : undefined;
+    });
 
   result = result.concat(
     data.character.customDefenseAdjustments
-      .filter(adjustment => adjustment.type === 2)
+      .filter(adjustment => adjustment.type === typeId)
       .map(adjustment => {
-        let entry = DICTIONARY.character.damageTypes.find(
-          type =>
-            (type.id =
-              adjustment.id &&
-              type.type === adjustment.type &&
-              type.kind === "immunity")
+        const entry = DICTIONARY.character.damageTypes.find(
+          type => (
+            type.id === adjustment.id &&
+            type.type === adjustment.type &&
+            type.kind === condition
+          )
         );
-        return entry ? entry.value : undefined;
+        return entry ? entry.vttaValue || entry.value : undefined;
       })
       .filter(adjustment => adjustment !== undefined)
   );
 
+  return result;
+};
+
+let getDamageImmunities = data => {
   return {
     custom: "",
-    value: result
+    value: getGenericConditionAffect(data, "immunity", 2)
   };
 };
 
 let getDamageResistances = data => {
-  let damageTypes = DICTIONARY.character.damageTypes
-    .filter(type => type.kind === "resistance" && type.type === 2)
-    .map(type => type.value);
-
-  let result = data.character.modifiers.race
-    .filter(
-      modifier =>
-        modifier.type === "resistance" && damageTypes.includes(modifier.subType)
-    )
-    .map(immunity => immunity.subType);
-
-  result = result.concat(
-    data.character.customDefenseAdjustments
-      .filter(adjustment => adjustment.type === 2)
-      .map(adjustment => {
-        let entry = DICTIONARY.character.damageTypes.find(
-          type =>
-            (type.id =
-              adjustment.id &&
-              type.type === adjustment.type &&
-              type.kind === "resistance")
-        );
-        return entry ? entry.value : undefined;
-      })
-      .filter(adjustment => adjustment !== undefined)
-  );
-
   return {
     custom: "",
-    value: result
+    value: getGenericConditionAffect(data, "resistance", 2)
   };
 };
 
 let getDamageVulnerabilities = data => {
-  let damageTypes = DICTIONARY.character.damageTypes
-    .filter(type => type.kind === "vulnerability" && type.type === 2)
-    .map(type => type.value);
-
-  let result = data.character.modifiers.race
-    .filter(
-      modifier =>
-        modifier.type === "vulnerability" &&
-        damageTypes.includes(modifier.subType)
-    )
-    .map(immunity => immunity.subType);
-
-  result = result.concat(
-    data.character.customDefenseAdjustments
-      .filter(adjustment => adjustment.type === 2)
-      .map(adjustment => {
-        let entry = DICTIONARY.character.damageTypes.find(
-          type =>
-            (type.id =
-              adjustment.id &&
-              type.type === adjustment.type &&
-              type.kind === "vulnerability")
-        );
-        return entry ? entry.value : undefined;
-      })
-      .filter(adjustment => adjustment !== undefined)
-  );
-
   return {
     custom: "",
-    value: result
+    value: getGenericConditionAffect(data, "vulnerability", 2)
   };
 };
 
 let getConditionImmunities = data => {
-  // get Custom Damage Vulnerability
-  let custom = data.character.customDefenseAdjustments
-    .filter(adjustment => adjustment.type === 1)
-    .map(adjustment => {
-      let entry = DICTIONARY.character.damageTypes.find(
-        type =>
-          (type.id =
-            adjustment.id &&
-            type.type === adjustment.type &&
-            type.kind === "immunity")
-      );
-      return entry ? entry.value : undefined;
-    })
-    .filter(adjustment => adjustment !== undefined);
-
+  // get Condition Immunities
   return {
     custom: "",
-    value: custom
+    value: getGenericConditionAffect(data, "immunity", 1)
   };
 };
 

--- a/src/parser/dictionary.js
+++ b/src/parser/dictionary.js
@@ -133,7 +133,7 @@ const DICTIONARY = {
             { name: 'Shield', value: 'shield' }
         ],
         damageTypes: [
-            { id: 1, type: 2, type: 2, kind: 'resistance', name: 'Bludgeoning', value: 'bludgeoning' },
+            { id: 1, type: 2, kind: 'resistance', name: 'Bludgeoning', value: 'bludgeoning' },
             { id: 2, type: 2, kind: 'resistance', name: 'Piercing', value: 'piercing' },
             { id: 3, type: 2, kind: 'resistance', name: 'Slashing', value: 'slashing' },
             { id: 4, type: 2, kind: 'resistance', name: 'Lightning', value: 'lightning' },
@@ -180,7 +180,7 @@ const DICTIONARY = {
             { id: 2, type: 1, kind: 'immunity', name: 'Charmed', value: 'charmed' },
             { id: 3, type: 1, kind: 'immunity', name: 'Deafened', value: 'deafened' },
             { id: 4, type: 1, kind: 'immunity', name: 'Exhaustion', value: 'exhaustion' },
-            { id: 5, type: 1, kind: 'immunity', name: 'Frightened', value: 'Frightened' },
+            { id: 5, type: 1, kind: 'immunity', name: 'Frightened', value: 'frightened' },
             { id: 6, type: 1, kind: 'immunity', name: 'Grappled', value: 'grappled' },
             { id: 7, type: 1, kind: 'immunity', name: 'Incapacitated', value: 'incapacitated' },
             { id: 8, type: 1, kind: 'immunity', name: 'Invisible', value: 'invisible' },
@@ -190,7 +190,9 @@ const DICTIONARY = {
             { id: 12, type: 1, kind: 'immunity', name: 'Prone', value: 'prone' },
             { id: 13, type: 1, kind: 'immunity', name: 'Restrained', value: 'restrained' },
             { id: 14, type: 1, kind: 'immunity', name: 'Stunned', value: 'stunned' },
-            { id: 15, type: 1, kind: 'immunity', name: 'Unconscious', value: 'unconscious' }
+            { id: 15, type: 1, kind: 'immunity', name: 'Unconscious', value: 'unconscious' },
+            // In DDB it is disease, but in FVTT ut is diseased
+            { id: 16, type: 1, kind: 'immunity', name: 'Diseased', value: 'disease', vttaValue: 'diseased' },
         ],
         proficiencies: [
             // Armor


### PR DESCRIPTION
Add disease condition to dictionary.

Allow lookup of conditions from modifiers. This is where the Paladin's
disease and frightened modifiers get placed.

Correct logic so custom conditions are detected.

Simplify duplicated code for reusability.