### PR TITLE
Global Attack Modifiers

### DIFF
--- a/src/parser/character/index.js
+++ b/src/parser/character/index.js
@@ -972,6 +972,23 @@ let getBonusAbilities = (data, character) => {
   return result;
 };
 
+let getBonusSpellDC = (data, character) => {
+  let result = {};
+  const bonusLookup = [
+    { fvttType: "dc", ddbSubType: "spell-save-dc" },
+  ];
+
+  bonusLookup.forEach(b => {
+    result[b.fvttType] = getGlobalBonus(
+      filterModifiers(data, "bonus", b.ddbSubType),
+      character,
+      b.ddbSubType
+    );
+  });
+
+  return result;
+};
+
 let getArmorProficiencies = (data, character) => {
   let values = [];
   let custom = [];
@@ -1587,15 +1604,14 @@ export default function getCharacter(ddb) {
   character.data.bonuses.rsak = getBonusSpellAttacks(ddb, character, 'ranged');
   character.data.bonuses.msak = getBonusSpellAttacks(ddb, character, 'melee');
   // spell dc
-  character.data.bonuses.spell = {
-    "dc": ""
-  };
+  character.data.bonuses.spell = getBonusSpellDC(ddb, character);
   // melee weapon attacks
   character.data.bonuses.mwak = {
     "attack": "",
     "damage": ""
   };
   // ranged weapon attacks
+  // e.g. ranged fighting style
   character.data.bonuses.rwak = {
     "attack": "",
     "damage": ""

--- a/src/parser/character/index.js
+++ b/src/parser/character/index.js
@@ -949,13 +949,38 @@ let getGlobalBonusAttackModifiers = (lookupTable, data, character) => {
 let getBonusSpellAttacks = (data, character, type) => {
   // I haven't found any matching global spell damage boosting mods in ddb
   const bonusLookups = [
-    { fvttType: "attack", ddbSubType: "magic" },
+//    { fvttType: "attack", ddbSubType: "magic" }, // not sure the scope of this
     { fvttType: "attack", ddbSubType: "spell-attacks" },
     { fvttType: "attack", ddbSubType: `${type}-spell-attacks` },
   ];
 
   return getGlobalBonusAttackModifiers(bonusLookups, data, character);
 };
+
+/**
+ * Gets global bonuses to weapon attacks and damage
+ * Most likely from items such as wand of the warmage
+ * supply type as 'ranged' or 'melee' 
+  {
+    "attack": "",
+    "damage": "",
+  },
+ * @param {*} data 
+ * @param {*} character 
+ * @param {*} type
+ */
+let getBonusWeaponAttacks = (data, character, type) => {
+  // global melee damage is not a ddb type, in that it's likely to be
+  // type specific. The only class one I know of is the Paladin Improved Smite
+  // which will be handled in the weapon import later.
+  const bonusLookups = [
+    { fvttType: "attack", ddbSubType: `${type}-attacks` },
+    { fvttType: "attack", ddbSubType: `${type}-weapon-attacks` },
+  ];
+
+  return getGlobalBonusAttackModifiers(bonusLookups, data, character);
+};
+
 
 /**
  * Gets global bonuses to ability checks, saves and skills
@@ -1622,16 +1647,10 @@ export default function getCharacter(ddb) {
   // spell dc
   character.data.bonuses.spell = getBonusSpellDC(ddb, character);
   // melee weapon attacks
-  character.data.bonuses.mwak = {
-    "attack": "",
-    "damage": ""
-  };
+  character.data.bonuses.mwak = getBonusWeaponAttacks(ddb, character, 'melee');
   // ranged weapon attacks
   // e.g. ranged fighting style
-  character.data.bonuses.rwak = {
-    "attack": "",
-    "damage": ""
-  };
+  character.data.bonuses.rwak = getBonusWeaponAttacks(ddb, character, 'ranged');
 
   return character;
 }

--- a/src/parser/character/index.js
+++ b/src/parser/character/index.js
@@ -869,32 +869,25 @@ let filterModifiers = (data, type, subType) => {
   return modifiers;
 };
 
+
 /**
- * Gets global bonuses to spell attacks and damage
- * Most likely from items such as wand of the warmage
- * supply type as 'ranged' or 'melee' 
+ * Gets global bonuses to attacks and damage
+ * Supply a list of maps that have the fvtt tyoe and ddb sub type, e,g,
+ * { fvttType: "attack", ddbSubType: "magic" }
   {
     "attack": "",
     "damage": "",
   },
+ * @param {*} lookupTable
  * @param {*} data 
  * @param {*} character 
- * @param {*} type
  */
-let getBonusSpellAttacks = (data, character, type) => {
+let getGlobalBonusAttackModifiers = (lookupTable, data, character) => {
   let result = {
     attack: "",
     damage: ""
   };
-
   const diceFormula = /\d*d\d*/;
-
-  // I haven't found any matching global spell damage boosting mods in ddb
-  const bonusLookup = [
-    { fvttType: "attack", ddbSubType: "magic" },
-    { fvttType: "attack", ddbSubType: "spell-attacks" },
-    { fvttType: "attack", ddbSubType: `${type}-spell-attacks` },
-  ];
 
   let lookupResults = {
     attack: {
@@ -907,7 +900,7 @@ let getBonusSpellAttacks = (data, character, type) => {
     },
   };
 
-  bonusLookup.forEach(b => {
+  lookupTable.forEach(b => {
     const lookupResult = getGlobalBonus(
       filterModifiers(data, "bonus", b.ddbSubType),
       character,
@@ -939,6 +932,29 @@ let getBonusSpellAttacks = (data, character, type) => {
   });
 
   return result;
+};
+
+/**
+ * Gets global bonuses to spell attacks and damage
+ * Most likely from items such as wand of the warmage
+ * supply type as 'ranged' or 'melee' 
+  {
+    "attack": "",
+    "damage": "",
+  },
+ * @param {*} data 
+ * @param {*} character 
+ * @param {*} type
+ */
+let getBonusSpellAttacks = (data, character, type) => {
+  // I haven't found any matching global spell damage boosting mods in ddb
+  const bonusLookups = [
+    { fvttType: "attack", ddbSubType: "magic" },
+    { fvttType: "attack", ddbSubType: "spell-attacks" },
+    { fvttType: "attack", ddbSubType: `${type}-spell-attacks` },
+  ];
+
+  return getGlobalBonusAttackModifiers(bonusLookups, data, character);
 };
 
 /**

--- a/src/parser/character/index.js
+++ b/src/parser/character/index.js
@@ -949,7 +949,6 @@ let getGlobalBonusAttackModifiers = (lookupTable, data, character) => {
 let getBonusSpellAttacks = (data, character, type) => {
   // I haven't found any matching global spell damage boosting mods in ddb
   const bonusLookups = [
-//    { fvttType: "attack", ddbSubType: "magic" }, // not sure the scope of this
     { fvttType: "attack", ddbSubType: "spell-attacks" },
     { fvttType: "attack", ddbSubType: `${type}-spell-attacks` },
   ];
@@ -975,6 +974,7 @@ let getBonusWeaponAttacks = (data, character, type) => {
   // which will be handled in the weapon import later.
   const bonusLookups = [
     { fvttType: "attack", ddbSubType: `${type}-attacks` },
+    { fvttType: "attack", ddbSubType: "weapon-attacks" },
     { fvttType: "attack", ddbSubType: `${type}-weapon-attacks` },
   ];
 


### PR DESCRIPTION
This adds global modifiers for:

* Melee/ranged weapon/spell attacks
* Spell DC

This helps capture boosts from items such as Wand of the War Mage, or the Fighters Ranged fighting style.