### PR TITLE
Support Improved Divine Smite

### DIFF
--- a/src/parser/inventory/weapon.js
+++ b/src/parser/inventory/weapon.js
@@ -187,7 +187,8 @@ let getMagicalBonus = data => {
  * @param {obj} weaponProperties weapon properties
  * /* damage: { parts: [], versatile: '' }, * /
  */
-let getDamage = (data, magicalDamageBonus) => {
+let getDamage = (data) => {
+  const magicalDamageBonus = getMagicalBonus(data);
   let versatile = data.definition.properties.find(
     property => property.name === "Versatile"
   );
@@ -219,7 +220,7 @@ let getDamage = (data, magicalDamageBonus) => {
 
   // additional damage parts
   // Note: For the time being, restricted additional bonus parts are not included in the damage
-  //       The Saving Throw Freature within Foundry is not fully implemented yet, to this will/might change
+  //       The Saving Throw Feature within Foundry is not fully implemented yet, to this will/might change
   data.definition.grantedModifiers
     .filter(
       mod =>
@@ -235,7 +236,7 @@ let getDamage = (data, magicalDamageBonus) => {
       }
     });
 
-  let result = {
+  const result = {
     parts: parts,
     versatile: versatile
   };
@@ -243,7 +244,7 @@ let getDamage = (data, magicalDamageBonus) => {
   return result;
 };
 
-export default function parseWeapon(data, character) {
+export default function parseWeapon(data, character, flags) {
   /**
    * MAIN parseWeapon
    */
@@ -359,9 +360,13 @@ export default function parseWeapon(data, character) {
   // we leave that as-is
 
   /* damage: { parts: [], versatile: '' }, */
-  // We are adding the magical bonus here, too.
-  // Not a friend of calculating it twice, but it's more obvious about what is happening and the calc is somewhat cheap
-  weapon.data.damage = getDamage(data, getMagicalBonus(data));
+  weapon.data.damage = getDamage(data);
+
+  if (flags.damage.parts) {
+    flags.damage.parts.forEach(part => {
+      weapon.data.damage.parts.push(part);
+    }); 
+  }
 
   /* formula: '', */
   // we leave that as-is

--- a/src/utils.js
+++ b/src/utils.js
@@ -65,6 +65,39 @@ let utils = {
 
     return nearestHit;
   },
+  filterBaseModifiers: (data, type, subType=null, restriction=["", null]) => {
+    const modifiers = [
+      data.character.modifiers.class,
+      data.character.modifiers.race,
+      data.character.modifiers.background,
+      data.character.modifiers.feat,
+      utils.getActiveItemModifiers(data),
+    ]
+      .flat()
+      .filter(modifier =>
+        modifier.type === type &&
+        ((subType !== null) ? modifier.subType === subType : true ) &&
+        restriction.find(r => r === modifier.restriction)
+      );
+
+    return modifiers;
+  },
+  getActiveItemModifiers: (data) => {
+    // get items we are going to interact on
+    const targetItems = data.character.inventory
+      .filter(item => 
+        (!item.definition.canEquip && !item.definition.canAttune) || // if item just gives a thing
+        (item.isAttuned) || // if it is attuned (assume equipped)
+        (!item.definition.canAttune && item.equipped) // can't attune but is equipped
+      );
+
+    const modifiers = data.character.modifiers.item
+      .filter(mod =>
+        targetItems.filter(item => item.id === mod.componentId)
+      );
+
+    return modifiers;
+  },
   calculateModifier: val => {
     return Math.floor((val - 10) / 2);
   },


### PR DESCRIPTION
This adds the Improved Divine Smite damage to all Melee Weapon attacks, by adding it to inventory items that support it.

This would also add any other matching Melee bonus damage restricted types, but I'm not aware of any others at present.