### PR TITLE
DND5E Now Always and AtWill Spells

### DIFF
--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -68,13 +68,15 @@ let getSpellPreparationMode = data => {
   let prepared = data.alwaysPrepared || data.prepared;
   // handle classSpells
   if (data.flags.vtta.dndbeyond.lookup === "classSpell") {
-    let classPrepMode = utils.findByProperty(
+    const classPrepMode = utils.findByProperty(
       DICTIONARY.spell.preparationModes,
       "name",
       data.flags.vtta.dndbeyond.class
-    );
-    if (prepMode) {
-      prepMode = classPrepMode.value;
+    ).value;
+    if (data.alwaysPrepared) {
+      prepMode = "always";
+    } else if (prepMode) {
+      prepMode = classPrepMode;
     };
     // Warlocks should use Pact spells, but these are not yet handled well
     // in VTTA (no slots are showed). Instead we mark as prepared, and 
@@ -97,15 +99,16 @@ let getSpellPreparationMode = data => {
     prepMode = "prepared";
   } else {
     // If spell doesn't use a spell slot and is not a cantrip, mark as always preped
-    let alwaysPrepared = (!data.usesSpellSlot && data.definition.level !== 0);
+    let always = (!data.usesSpellSlot && data.definition.level !== 0);
     let ritaulOnly = (data.ritualCastingType !== null|| data.castOnlyAsRitual); // e.g. Book of ancient secrets & totem barb
-    if (alwaysPrepared && ritaulOnly) {
+    if (always && ritaulOnly) {
       // in this case we want the spell to appear in the spell list unprepared
       prepared = false;
-    } else if (alwaysPrepared) {
+    } else if (always) {
       // these spells are always prepared, and have a limited use that's
       // picked up by getUses() later
-      prepMode = "always";
+      // this was changed to "atwill"
+      prepMode = "atwill";
     };
   };
 

--- a/src/parser/dictionary.js
+++ b/src/parser/dictionary.js
@@ -607,32 +607,18 @@ const DICTIONARY = {
   },
   spell: {
     preparationModes: [
-      // This is the correct table
-      /*
-            { name: 'Hunter', value: 'always' },
-            { name: 'Bard', value: 'always' },
-            { name: 'Rogue', value: 'always' },
-            { name: 'Sorcerer', value: 'always' },
-            { name: 'Artificer', value: 'always' },
-            { name: 'Cleric', value: 'prepared' },
-            { name: 'Wizard', value: 'prepared' },
-            { name: 'Paladin', value: 'prepared' },
-            { name: 'Druid', value: 'prepared' },
-            { name: 'Warlock', value: 'pact' }
-            */
-      // this table works for the current Foundry UI
-      { name: "Hunter", value: "prepared" },
-      { name: "Bard", value: "prepared" },
-      { name: "Rogue", value: "prepared" },
-      { name: "Sorcerer", value: "prepared" },
       { name: "Artificer", value: "prepared" },
-      { name: "Cleric", value: "prepared" },
-      { name: "Wizard", value: "prepared" },
-      { name: "Paladin", value: "prepared" },
-      { name: "Druid", value: "prepared" },
-      { name: "Warlock", value: "pact" },
-      { name: "Fighter", value: "prepared" },
+      { name: "Bard", value: "always" },
       { name: "Blood Hunter", value: "pact" },
+      { name: "Cleric", value: "prepared" },
+      { name: "Druid", value: "prepared" },
+      { name: "Fighter", value: "always" },
+      { name: "Hunter", value: "always" },
+      { name: "Paladin", value: "prepared" },
+      { name: "Rogue", value: "always" },
+      { name: "Sorcerer", value: "always" },
+      { name: "Warlock", value: "pact" },
+      { name: "Wizard", value: "prepared" },
     ],
     activationTypes: [
       { activationType: 0, value: "none" },


### PR DESCRIPTION
Spell Types have changed. Always available is now At Will, and always is
for spellcasters like the sorcerer and Cleric Domain spells.

This is for 0.88 version of DnD5E system (to be released later in April).