### PR TITLE
Correct Spell Targets

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "vtta-dndbeyond",
   "title": "Virtual Tabletop Assets - D&D Beyond Integration",
   "description": "Bringing your licensed content from D&D Beyond into Foundry VTT",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "minimumCoreVersion": "0.5.5",
   "compatibleCoreVersion": "0.5.5",
   "author": "Sebastian Will",

--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -233,10 +233,23 @@ let getTarget = data => {
   let units = null;
   let value = null;
 
-  const creature = /(a creature you|creature( that)? you can see|interrupt a creature)|would strike a creature|creature of your choice|creature or object within range|cause a creature|creature must be within range/i;
-  const creaturesRange = /(humanoid|monster|creature|target)(s)? (or loose object )?(of your choice )?(that )?(you can see )?within range/i;
-  const creatures = creature.exec(data.definition.description) ||
-    creaturesRange.exec(data.definition.description);
+  const creature = /a creature you|creature( that)? you can see|interrupt a creature|would strike a creature|creature of your choice|creature or object within range|cause a creature|creature must be within range/gi;
+  const creaturesRange = /(humanoid|monster|creature|target)(s)? (or loose object )?(of your choice )?(that )?(you can see )?within range/gi;
+  const creatures = data.definition.description.match(creature) ||
+    data.definition.description.match(creaturesRange);
+
+  if (creatures) {
+    const numCreatures = /(?!At Higher Levels.*)(\w*) (falling )?(willing )?(creature|target|monster|celestial|fiend|fey|corpse(s)? of|humanoid)(?!.*you have animated)/gmi;
+    const targets = [...data.definition.description.matchAll(numCreatures)];
+    const targetValues = targets
+      .filter(target => {
+        const matches = DICTIONARY.numbers.filter(n => n.natural === target[1].toLowerCase())
+        return Array.isArray(matches) && !!matches.length;
+      })
+      .map(target => DICTIONARY.numbers.find(n => n.natural === target[1].toLowerCase()).num)
+
+    if (Array.isArray(targetValues) && !!targetValues.length) value = Math.max(...targetValues);
+  }
 
   switch (data.definition.range.origin) {
     case "Touch":
@@ -271,7 +284,7 @@ let getTarget = data => {
   };
 
   return {
-    value: value, // dd beyond doesn't let us know how many folk a spell can target
+    value: value,
     units: units, 
     type: type,
   };

--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -217,6 +217,16 @@ let getDuration = data => {
 
 /** Spell targets 
  * 
+ *             "target": {
+                "value": 4,
+                "units": "mi",
+                "type": "creature"
+            },
+            "range": {
+                "value": 30,
+                "long": 30,
+                "units": "ft"
+            },
 */
 let getTarget = data => {
   // if spell is an AOE effect get some details
@@ -230,11 +240,13 @@ let getTarget = data => {
 
   // else lets try and fill in some target details
   let type = "";
-  let units = "";
+  let units = null;
+  let value = null;
 
   switch (data.definition.range.origin) {
     case "Touch":
-      type = "touch";
+      units = "touch"
+      type = "creature";
       break;
     case "Self":
       type = "self";
@@ -243,21 +255,19 @@ let getTarget = data => {
       type = "none";
       break;
     case "Ranged":
-      type = "feet";
+      type = "creature";
       break;
     case "Feet":
-      type = "feet";
-      units = "ft";
+      type = "creature";
       break;
     case "Miles":
-      type = "miles";
-      units = "ml";
+      type = "creature";
       break;
     case "Special":
-      type = "special";
+      units = "special";
       break;
     case "Any":
-      type = "any";
+      units = "any";
       break;
     case undefined:
       type = null;
@@ -265,7 +275,7 @@ let getTarget = data => {
   };
 
   return {
-    value: null, // dd beyond doesn't let us know how many folk a spell can target
+    value: value, // dd beyond doesn't let us know how many folk a spell can target
     units: units, 
     type: type,
   };

--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -215,18 +215,8 @@ let getDuration = data => {
   }
 };
 
-/** Spell targets 
- * 
- *             "target": {
-                "value": 4,
-                "units": "mi",
-                "type": "creature"
-            },
-            "range": {
-                "value": 30,
-                "long": 30,
-                "units": "ft"
-            },
+/**
+ * Spell targets 
 */
 let getTarget = data => {
   // if spell is an AOE effect get some details
@@ -239,14 +229,19 @@ let getTarget = data => {
   }
 
   // else lets try and fill in some target details
-  let type = "";
+  let type = null;
   let units = null;
   let value = null;
+
+  const creature = /(a creature you|creature( that)? you can see|interrupt a creature)|would strike a creature|creature of your choice|creature or object within range|cause a creature|creature must be within range/i;
+  const creaturesRange = /(humanoid|monster|creature|target)(s)? (or loose object )?(of your choice )?(that )?(you can see )?within range/i;
+  const creatures = creature.exec(data.definition.description) ||
+    creaturesRange.exec(data.definition.description);
 
   switch (data.definition.range.origin) {
     case "Touch":
       units = "touch"
-      type = "creature";
+      if (creatures) type = "creature";
       break;
     case "Self":
       type = "self";
@@ -255,14 +250,15 @@ let getTarget = data => {
       type = "none";
       break;
     case "Ranged":
-      type = "creature";
+      if (creatures) type = "creature";
       break;
     case "Feet":
-      type = "creature";
+      if (creatures) type = "creature";
       break;
     case "Miles":
-      type = "creature";
+      if (creatures) type = "creature";
       break;
+    case "Sight":
     case "Special":
       units = "special";
       break;
@@ -309,6 +305,7 @@ let getRange = data => {
     case "Miles":
       units = "ml";
       break;
+    case "Sight":
     case "Special":
       units = "special";
       break;

--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -283,14 +283,48 @@ let getTarget = data => {
 
 /** Spell range */
 let getRange = data => {
+  // else lets try and fill in some target details
+  let value = data.definition.range.rangeValue ? data.definition.range.rangeValue: null;
+  let units = "ft";
+  let long = null;
+  
+  switch (data.definition.range.origin) {
+    case "Touch":
+      value = null;
+      units = "touch"
+      break;
+    case "Self":
+      value = null;
+      units = "self";
+      break;
+    case "None":
+      units = "none";
+      break;
+    case "Ranged":
+      units = "ft";
+      break;
+    case "Feet":
+      units = "ft";
+      break;
+    case "Miles":
+      units = "ml";
+      break;
+    case "Special":
+      units = "special";
+      break;
+    case "Any":
+      units = "any";
+      break;
+    case undefined:
+      units = null;
+      break;
+  };
+
+
   return {
-    value: data.definition.range.rangeValue
-      ? data.definition.range.rangeValue
-      : 5,
-    long: data.definition.range.rangeValue
-      ? data.definition.range.rangeValue
-      : 5,
-    units: "ft"
+    value:value,
+    long: long,
+    units: units
   };
 };
 

--- a/src/parser/dictionary.js
+++ b/src/parser/dictionary.js
@@ -1,4 +1,27 @@
 const DICTIONARY = {
+  numbers: [
+    { num:1 , natural: "a" },
+    { num:1 , natural: "one" },
+    { num:2 , natural: "two" },
+    { num:3 , natural: "three" },
+    { num:4 , natural: "four" },
+    { num:5 , natural: "five" },
+    { num:6 , natural: "six" },
+    { num:7 , natural: "seven" },
+    { num:8 , natural: "eight" },
+    { num:9 , natural: "nine" },
+    { num:10 , natural: "ten" },
+    { num:11 , natural: "eleven" },
+    { num:12 , natural: "twelve" },
+    { num:13 , natural: "thirteen" },
+    { num:14 , natural: "fourteen" },
+    { num:15 , natural: "fifteen" },
+    { num:16 , natural: "sixteen" },
+    { num:17 , natural: "seventeen" },
+    { num:18 , natural: "eighteen" },
+    { num:19 , natural: "nineteen" },
+    { num:20 , natural: "twenty" },
+  ],
   magicitems: {
     rechargeUnits: [
       { id: 1, value: "r4" },


### PR DESCRIPTION
Corrects a bug where spell targets were removed.

Added back in with some enhancements to try and parse out target numbers for a spell as well.

Range is also improved to match sample SRD format spells, and long range is removed.