### PR TITLE
Healing Potions: Parse as potions 

### DIFF
--- a/src/parser/inventory/index.js
+++ b/src/parser/inventory/index.js
@@ -88,6 +88,9 @@ let parseItem = (ddb, data, character) => {
         break;
       case 'Other Gear':
         switch (data.definition.subType) {
+          case 'Potion':
+            return parsePotion(data, character);
+            break;
           case 'Tool':
             return parseTool(data, character);
             break;


### PR DESCRIPTION
Healing potions does not show itself as a potion like other magic
potions.

Parse it by potion so it appears as a consumable.

This will not have any charges set.