### PR TITLE
Magic Weapons: Apply type damage

### DIFF
--- a/src/parser/inventory/weapon.js
+++ b/src/parser/inventory/weapon.js
@@ -239,11 +239,11 @@ let getDamage = (data, flags) => {
 
   // additional damage parts
   // Note: For the time being, restricted additional bonus parts are not included in the damage
-  //       The Saving Throw Feature within Foundry is not fully implemented yet, to this will/might change
   data.definition.grantedModifiers
     .filter(
       mod =>
-        mod.type === "damage" && mod.restriction && mod.restriction.length === 0
+      mod.type === "damage" &&
+      (!mod.restriction || (!!mod.restriction && mod.restriction === ""))
     )
     .forEach(mod => {
       if (mod.dice) {


### PR DESCRIPTION
The formula for detecting if a weapon had additional damage was incorrect.