### PR TITLE
Fix Thunderclap range and target

### DIFF
--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -1027,6 +1027,16 @@ export default function parseSpells(ddb, character) {
     eb.data.range.long += eldritchBlastMods['range'];
   });
 
+  // Thunderclap's target/range input data are incorrect
+  // Range is self with an AoE target of 15 ft cube
+  // i.e. affects all creatures within 5 ft of caster
+  items.filter(
+    spell => spell.name === "Thunderclap"
+  ).map(tc => {
+    tc.data.range = {value: null, units: "self", long: null};
+    tc.data.target = {value: "15", units: "ft", type: "cube"};
+  });
+ 
   return items;
 }
 


### PR DESCRIPTION
Thunderclap's DDB data (5 foot range) results in target/range values
that are incorrect in Foundry. Treat it as a special case so it correctly
targets a 15 ft cube with range self.