### PR TITLE
Fixed used hit dice.

### DIFF
--- a/src/parser/character/classes.js
+++ b/src/parser/character/classes.js
@@ -51,6 +51,7 @@ export default function parseClasses(ddb, character) {
     }
 
     item.data.hitDice = `d${characterClass.definition.hitDice}`;
+    item.data.hitDiceUsed = characterClass.hitDiceUsed;
 
     // There class object supports skills granted by the class.
     // Lets find and add them for future compatibility.

--- a/src/parser/character/index.js
+++ b/src/parser/character/index.js
@@ -162,11 +162,7 @@ let getAbilities = (data, character) => {
 let getHitDice = (data, character) => {
   let used = data.character.classes.reduce((prev, cls) => prev + cls.hitDiceUsed, 0);
   let total = data.character.classes.reduce((prev, cls) => prev + cls.level, 0);
-  return {
-    value: total - used,
-    min: 1,
-    max: total,
-  };
+  return total - used;
 };
 
 let getDeathSaves = (data, character) => {


### PR DESCRIPTION
Used hit dice is calculated in foundry from the class features by summing the total & used.

The attribute hit dice field has changed from an object to just a basic value of the number available.

This pull request brings vtta-dndbeyond in line with these changes and fixes hit die importing.