### PR TITLE
Set cantrip spell scale to blank

### DIFF
--- a/src/parser/character/spells.js
+++ b/src/parser/character/spells.js
@@ -554,7 +554,7 @@ let getSpellScaling = (data) => {
     case "characterlevel":
       return {
         mode: "cantrip",
-        formula: baseDamage,
+        formula: "",
       };
     case "spellscale":
       return {


### PR DESCRIPTION
This fixes the bug where spells like Toll the Dead don't scale for versatile damage.