### PR TITLE
Added spell restrictions on monster import

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -619,11 +619,12 @@ let utils = {
       // replace non-null values with the complete entity from the compendium
       let entities = await Promise.all(
         indices.map((entry) => {
-          return new Promise(async (resolve) => {
+          return new Promise((resolve) => {
             if (entry) {
-              let entity = await compendium.getEntity(entry._id);
-              entity.data.name = entry.name; // transfer restrictions over, if any
-              resolve(entity);
+              compendium.getEntity(entry._id).then((entity) => {
+                entity.data.name = entry.name; // transfer restrictions over, if any
+                resolve(entity);
+              });
             } else {
               resolve(null);
             }


### PR DESCRIPTION
Added successful spell lookups on monster import if the spell name on dndbeyond contained restrictions/ additional information in paranthesis, see: https://www.dndbeyond.com/monsters/ygorl-lord-of-entropy

Symbol (death only), Symbol (discord only).

The spells are reduced to the main part and the restrictions are retained on spell assignment