### PR TITLE
Do not import multiple generics

### DIFF
--- a/src/messaging/type/add/npc.js
+++ b/src/messaging/type/add/npc.js
@@ -186,7 +186,7 @@ let buildNPC = async (data) => {
               // eslint-disable-next-line require-atomic-updates
               data.img = await utils.uploadImage(dndBeyondImageUrl, uploadDirectory, filename);
           } else {
-			  // eslint-disable-next-line require-atomic-updates
+              // eslint-disable-next-line require-atomic-updates
               data.img = utils.getFileUrl(uploadDirectory, filename + "." + ext);
           }
       } else {

--- a/src/messaging/type/add/npc.js
+++ b/src/messaging/type/add/npc.js
@@ -186,7 +186,8 @@ let buildNPC = async (data) => {
               // eslint-disable-next-line require-atomic-updates
               data.img = await utils.uploadImage(dndBeyondImageUrl, uploadDirectory, filename);
           } else {
-              data.img = utils.getFileUrl(uploadDirectory, filename + "." +ext);
+			  // eslint-disable-next-line require-atomic-updates
+              data.img = utils.getFileUrl(uploadDirectory, filename + "." + ext);
           }
       } else {
           // image upload

--- a/src/messaging/type/add/npc.js
+++ b/src/messaging/type/add/npc.js
@@ -165,21 +165,29 @@ let buildNPC = async (data) => {
       await npc.createEmbeddedEntity("OwnedItem", spells);
     }
   } else {
-    if (data.flags.vtta.dndbeyond.img) {
+	let dndBeyondImageUrl = data.flags.vtta.dndbeyond.img;
+    if (dndBeyondImageUrl) {
 	  let uploadDirectory = game.settings.get("vtta-dndbeyond", "image-upload-directory").replace(/^\/|\/$/g, "");
       // in this instance I can't figure out how to make this safe, but the risk seems minimal.
 	  
-	  if (data.flags.vtta.dndbeyond.img.includes("attachments")) {
+	  if (dndBeyondImageUrl.includes("attachments")) {
 		  let npcType = data.data.details.type;
-		  let filename = "generic-" + npcType
+		  let filename = "npc-generic-" + npcType
 			  .replace(/[^a-zA-Z]/g, "-")
 			  .replace(/-+/g, "-")
 			  .trim();
 			  
-		  //if (!(await srcExists(uploadDirectory + "/" + filename))) {
+		  let ext = dndBeyondImageUrl
+			  .split(".")
+			  .pop()
+			  .split(/#|\?|&/)[0];
+			  
+		  if (!(await utils.fileExists(uploadDirectory, filename + "." + ext))) {
 			  // eslint-disable-next-line require-atomic-updates
-			  data.img = await utils.uploadImage(data.flags.vtta.dndbeyond.img, uploadDirectory, filename);
-		  //}
+			  data.img = await utils.uploadImage(dndBeyondImageUrl, uploadDirectory, filename);
+		  } else {
+			  data.img = utils.getFileUrl(uploadDirectory, filename + "." +ext);
+		  }
 	  } else {
 		  // image upload
 		  let filename =
@@ -190,7 +198,7 @@ let buildNPC = async (data) => {
 			  .trim();
 
 		  // eslint-disable-next-line require-atomic-updates
-		  data.img = await utils.uploadImage(data.flags.vtta.dndbeyond.img, uploadDirectory, filename);
+		  data.img = await utils.uploadImage(dndBeyondImageUrl, uploadDirectory, filename);
 	  }
     }
 

--- a/src/messaging/type/add/npc.js
+++ b/src/messaging/type/add/npc.js
@@ -170,17 +170,17 @@ let buildNPC = async (data) => {
       let uploadDirectory = game.settings.get("vtta-dndbeyond", "image-upload-directory").replace(/^\/|\/$/g, "");
       // in this instance I can't figure out how to make this safe, but the risk seems minimal.
 
-      if (dndBeyondImageUrl.includes("attachments")) {
-          let npcType = data.data.details.type;
+      let npcType = data.data.details.type;
+      let ext = dndBeyondImageUrl
+              .split(".")
+              .pop()
+              .split(/#|\?|&/)[0];
+              
+      if (dndBeyondImageUrl.endsWith(npcType + "." + ext)) {
           let filename = "npc-generic-" + npcType
               .replace(/[^a-zA-Z]/g, "-")
               .replace(/-+/g, "-")
               .trim();
-              
-          let ext = dndBeyondImageUrl
-              .split(".")
-              .pop()
-              .split(/#|\?|&/)[0];
               
           if (!(await utils.fileExists(uploadDirectory, filename + "." + ext))) {
               // eslint-disable-next-line require-atomic-updates

--- a/src/messaging/type/add/npc.js
+++ b/src/messaging/type/add/npc.js
@@ -166,18 +166,32 @@ let buildNPC = async (data) => {
     }
   } else {
     if (data.flags.vtta.dndbeyond.img) {
-      // image upload
-      let filename =
-        "npc-" +
-        data.name
-          .replace(/[^a-zA-Z]/g, "-")
-          .replace(/-+/g, "-")
-          .trim();
-
-      let uploadDirectory = game.settings.get("vtta-dndbeyond", "image-upload-directory").replace(/^\/|\/$/g, "");
+	  let uploadDirectory = game.settings.get("vtta-dndbeyond", "image-upload-directory").replace(/^\/|\/$/g, "");
       // in this instance I can't figure out how to make this safe, but the risk seems minimal.
-      // eslint-disable-next-line require-atomic-updates
-      data.img = await utils.uploadImage(data.flags.vtta.dndbeyond.img, uploadDirectory, filename);
+	  
+	  if (data.flags.vtta.dndbeyond.img.includes("attachments")) {
+		  let npcType = data.data.details.type;
+		  let filename = "generic-" + npcType
+			  .replace(/[^a-zA-Z]/g, "-")
+			  .replace(/-+/g, "-")
+			  .trim();
+			  
+		  //if (!(await srcExists(uploadDirectory + "/" + filename))) {
+			  // eslint-disable-next-line require-atomic-updates
+			  data.img = await utils.uploadImage(data.flags.vtta.dndbeyond.img, uploadDirectory, filename);
+		  //}
+	  } else {
+		  // image upload
+		  let filename =
+			"npc-" +
+			data.name
+			  .replace(/[^a-zA-Z]/g, "-")
+			  .replace(/-+/g, "-")
+			  .trim();
+
+		  // eslint-disable-next-line require-atomic-updates
+		  data.img = await utils.uploadImage(data.flags.vtta.dndbeyond.img, uploadDirectory, filename);
+	  }
     }
 
     // create the new npc

--- a/src/messaging/type/add/npc.js
+++ b/src/messaging/type/add/npc.js
@@ -165,41 +165,41 @@ let buildNPC = async (data) => {
       await npc.createEmbeddedEntity("OwnedItem", spells);
     }
   } else {
-	let dndBeyondImageUrl = data.flags.vtta.dndbeyond.img;
+    let dndBeyondImageUrl = data.flags.vtta.dndbeyond.img;
     if (dndBeyondImageUrl) {
-	  let uploadDirectory = game.settings.get("vtta-dndbeyond", "image-upload-directory").replace(/^\/|\/$/g, "");
+      let uploadDirectory = game.settings.get("vtta-dndbeyond", "image-upload-directory").replace(/^\/|\/$/g, "");
       // in this instance I can't figure out how to make this safe, but the risk seems minimal.
-	  
-	  if (dndBeyondImageUrl.includes("attachments")) {
-		  let npcType = data.data.details.type;
-		  let filename = "npc-generic-" + npcType
-			  .replace(/[^a-zA-Z]/g, "-")
-			  .replace(/-+/g, "-")
-			  .trim();
-			  
-		  let ext = dndBeyondImageUrl
-			  .split(".")
-			  .pop()
-			  .split(/#|\?|&/)[0];
-			  
-		  if (!(await utils.fileExists(uploadDirectory, filename + "." + ext))) {
-			  // eslint-disable-next-line require-atomic-updates
-			  data.img = await utils.uploadImage(dndBeyondImageUrl, uploadDirectory, filename);
-		  } else {
-			  data.img = utils.getFileUrl(uploadDirectory, filename + "." +ext);
-		  }
-	  } else {
-		  // image upload
-		  let filename =
-			"npc-" +
-			data.name
-			  .replace(/[^a-zA-Z]/g, "-")
-			  .replace(/-+/g, "-")
-			  .trim();
 
-		  // eslint-disable-next-line require-atomic-updates
-		  data.img = await utils.uploadImage(dndBeyondImageUrl, uploadDirectory, filename);
-	  }
+      if (dndBeyondImageUrl.includes("attachments")) {
+          let npcType = data.data.details.type;
+          let filename = "npc-generic-" + npcType
+              .replace(/[^a-zA-Z]/g, "-")
+              .replace(/-+/g, "-")
+              .trim();
+              
+          let ext = dndBeyondImageUrl
+              .split(".")
+              .pop()
+              .split(/#|\?|&/)[0];
+              
+          if (!(await utils.fileExists(uploadDirectory, filename + "." + ext))) {
+              // eslint-disable-next-line require-atomic-updates
+              data.img = await utils.uploadImage(dndBeyondImageUrl, uploadDirectory, filename);
+          } else {
+              data.img = utils.getFileUrl(uploadDirectory, filename + "." +ext);
+          }
+      } else {
+          // image upload
+          let filename =
+            "npc-" +
+            data.name
+              .replace(/[^a-zA-Z]/g, "-")
+              .replace(/-+/g, "-")
+              .trim();
+
+          // eslint-disable-next-line require-atomic-updates
+          data.img = await utils.uploadImage(dndBeyondImageUrl, uploadDirectory, filename);
+      }
     }
 
     // create the new npc

--- a/src/utils.js
+++ b/src/utils.js
@@ -362,7 +362,7 @@ let utils = {
     try {
         await utils.serverFileExists(DirectoryPicker.parse(directoryPath).current + "/" + filename);
         return true;
-    } catch {
+    } catch (ignored) {
         return false;
     }
   },

--- a/src/utils.js
+++ b/src/utils.js
@@ -718,11 +718,11 @@ let utils = {
   },
 
   fileExists: (directoryPath, filename) => {
-	return srcExists(DirectoryPicker.parse(directoryPath).current + "/" + filename);
+    return srcExists(DirectoryPicker.parse(directoryPath).current + "/" + filename);
   },
 
   getFileUrl: (directoryPath, filename) => {
-	  return DirectoryPicker.parse(directoryPath).current + "/" + filename;
+    return DirectoryPicker.parse(directoryPath).current + "/" + filename;
   },
 
   versionCompare: (v1, v2, options) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -717,6 +717,14 @@ let utils = {
       }
   },
 
+  fileExists: (directoryPath, filename) => {
+	return srcExists(DirectoryPicker.parse(directoryPath).current + "/" + filename);
+  },
+
+  getFileUrl: (directoryPath, filename) => {
+	  return DirectoryPicker.parse(directoryPath).current + "/" + filename;
+  },
+
   versionCompare: (v1, v2, options) => {
     var lexicographical = options && options.lexicographical,
       zeroExtend = options && options.zeroExtend,

--- a/src/utils.js
+++ b/src/utils.js
@@ -353,7 +353,18 @@ let utils = {
           }
         }
       };
+      
+      http.send();
     });
+  },
+  
+  fileExists: async (directoryPath, filename) => {
+    try {
+        await utils.serverFileExists(DirectoryPicker.parse(directoryPath).current + "/" + filename);
+        return true;
+    } catch {
+        return false;
+    }
   },
 
   getTemplate: (type) => {
@@ -715,10 +726,6 @@ let utils = {
         default:
           console.log(`${LOG_PREFIX} | ${section} > ${msg}`); // eslint-disable-line no-console
       }
-  },
-
-  fileExists: (directoryPath, filename) => {
-    return srcExists(DirectoryPicker.parse(directoryPath).current + "/" + filename);
   },
 
   getFileUrl: (directoryPath, filename) => {


### PR DESCRIPTION
A lot of DNDBeyond monsters don't have an image and we are importing the default generic one over and over again as a different image.

This uses the fact that this image is located in a different path (including "attachments") to identify such images and download them only once then refer to the same image for all the other monsters.

This really might not be in your conventions and/or good practice for FVTT development as this is my first dive into this.
Feel free to let me know what you think, I can change things if needed.