### PR TITLE
Add Update Selection option for Currency

### DIFF
--- a/src/character/import.js
+++ b/src/character/import.js
@@ -478,6 +478,11 @@ export default class CharacterImport extends Application {
         description: "Other inventory items",
       },
       {
+        name: "currency",
+        isChecked: game.settings.get("vtta-dndbeyond", "character-update-policy-currency"),
+        description: "Currency",
+      },
+      {
         name: "spell",
         isChecked: game.settings.get("vtta-dndbeyond", "character-update-policy-spell"),
         description: "Spells",
@@ -599,6 +604,12 @@ export default class CharacterImport extends Application {
         if (!importKeepExistingActorItems) {
           CharacterImport.showCurrentTask(html, "Clearing inventory");
           await this.clearItemsByUserSelection();
+        }
+
+        // manage updates of basic character data more intelligently
+        if (!game.settings.get("vtta-dndbeyond", "character-update-policy-currency")) {
+          // revert currency if user didn't select to update it
+          this.actor.data.data.currency = this.actorOriginal.data.currency;
         }
 
         // store all spells in the folder specific for Dynamic Items

--- a/src/hooks/ready/registerGameSettings.js
+++ b/src/hooks/ready/registerGameSettings.js
@@ -190,6 +190,16 @@ export default function () {
     }
   );
 
+  game.settings.register("vtta-dndbeyond", "character-update-policy-currency", {
+    name: "vtta-dndbeyond.character-update-policy-currency.name",
+    hint: "vtta-dndbeyond.character-update-policy-currency.hint",
+    scope: "player",
+    config: false,
+    type: Boolean,
+    default: true,
+  }
+  );
+
   game.settings.register("vtta-dndbeyond", "character-update-policy-spell", {
     name: "vtta-dndbeyond.character-update-policy-spell.name",
     hint: "vtta-dndbeyond.character-update-policy-spell.hint",


### PR DESCRIPTION
I've added an option in the "Update selection" area of character imports that allows the user to chose weather or not to update currency values on the Foundry actor with those found in the ddb character. As there is no distinction between this update option and the "New items only" configuration item it ignores the "New items only" setting.

Note that I very nearly overwrote changes from the merge of @MrPrimate's pull request that added compendiums for classes and features. I believe I fully corrected that before submitting this, but it may be worth paying extra attention to that aspect when reviewing/testing before approving the pull request.