### PR TITLE
Hotfix Issue #268 by disabling My DDB Classes compendium

### DIFF
--- a/src/character/import.js
+++ b/src/character/import.js
@@ -623,7 +623,9 @@ export default class CharacterImport extends Application {
         this.updateCompendium("inventory");
         this.updateCompendium("spells");
         this.updateCompendium("features");
+        /* Issue #263 hotfix - remove Classes Compendium (for now)
         this.updateCompendium("classes");
+        */
 
         // Adding all items to the actor
         const FILTER_SECTIONS = ["classes", "features", "actions", "inventory", "spells"];
@@ -649,12 +651,16 @@ export default class CharacterImport extends Application {
           const compendiumInventoryItems = await CharacterImport.getCompendiumItems(items, "inventory");
           const compendiumSpellItems = await CharacterImport.getCompendiumItems(items, "spells");
           const compendiumFeatureItems = await CharacterImport.getCompendiumItems(items, "features");
+          /* Issue #263 hotfix - remove Classes Compendium (for now)
           const compendiumClassItems = await CharacterImport.getCompendiumItems(items, "classes");
+          */
           compendiumItems = compendiumItems.concat(
             compendiumInventoryItems,
             compendiumSpellItems,
             compendiumFeatureItems,
+            /* Issue #263 hotfix - remove Classes Compendium (for now)
             compendiumClassItems,
+            */
           );
           // removed existing items from those to be imported
           items = await CharacterImport.removeItems(items, compendiumItems);


### PR DESCRIPTION
There may be a more elegant way of dealing with this and keeping the My DDB Classes compendium but the current behaviour is quite nasty when importing characters (see Issue #268) so its preferable to disable while we assess whether any better options exist (such as copying the dnd5e system's Classes compendium into My DDB Classes on creation and overriding values of character-specific fields such as "Class Levels" on the Class object with ones from the ddb parse).

