### PR TITLE
Remove Class compendium

### DIFF
--- a/src/character/import.js
+++ b/src/character/import.js
@@ -624,7 +624,7 @@ export default class CharacterImport extends Application {
         this.updateCompendium("spells");
         this.updateCompendium("features");
         // Issue #263 hotfix - remove Classes Compendium (for now)
-        //this.updateCompendium("classes");
+        // this.updateCompendium("classes");
         
         // Adding all items to the actor
         const FILTER_SECTIONS = ["classes", "features", "actions", "inventory", "spells"];
@@ -651,14 +651,14 @@ export default class CharacterImport extends Application {
           const compendiumSpellItems = await CharacterImport.getCompendiumItems(items, "spells");
           const compendiumFeatureItems = await CharacterImport.getCompendiumItems(items, "features");
           // Issue #263 hotfix - remove Classes Compendium (for now)
-          //const compendiumClassItems = await CharacterImport.getCompendiumItems(items, "classes");
+          // const compendiumClassItems = await CharacterImport.getCompendiumItems(items, "classes");
           
           compendiumItems = compendiumItems.concat(
             compendiumInventoryItems,
             compendiumSpellItems,
             compendiumFeatureItems,
             // Issue #263 hotfix - remove Classes Compendium (for now)
-            //compendiumClassItems,
+            // compendiumClassItems,
           );
           // removed existing items from those to be imported
           items = await CharacterImport.removeItems(items, compendiumItems);

--- a/src/character/import.js
+++ b/src/character/import.js
@@ -623,10 +623,9 @@ export default class CharacterImport extends Application {
         this.updateCompendium("inventory");
         this.updateCompendium("spells");
         this.updateCompendium("features");
-        /* Issue #263 hotfix - remove Classes Compendium (for now)
-        this.updateCompendium("classes");
-        */
-
+        // Issue #263 hotfix - remove Classes Compendium (for now)
+        //this.updateCompendium("classes");
+        
         // Adding all items to the actor
         const FILTER_SECTIONS = ["classes", "features", "actions", "inventory", "spells"];
         let items = filterItemsByUserSelection(this.result, FILTER_SECTIONS);
@@ -651,16 +650,15 @@ export default class CharacterImport extends Application {
           const compendiumInventoryItems = await CharacterImport.getCompendiumItems(items, "inventory");
           const compendiumSpellItems = await CharacterImport.getCompendiumItems(items, "spells");
           const compendiumFeatureItems = await CharacterImport.getCompendiumItems(items, "features");
-          /* Issue #263 hotfix - remove Classes Compendium (for now)
-          const compendiumClassItems = await CharacterImport.getCompendiumItems(items, "classes");
-          */
+          // Issue #263 hotfix - remove Classes Compendium (for now)
+          //const compendiumClassItems = await CharacterImport.getCompendiumItems(items, "classes");
+          
           compendiumItems = compendiumItems.concat(
             compendiumInventoryItems,
             compendiumSpellItems,
             compendiumFeatureItems,
-            /* Issue #263 hotfix - remove Classes Compendium (for now)
-            compendiumClassItems,
-            */
+            // Issue #263 hotfix - remove Classes Compendium (for now)
+            //compendiumClassItems,
           );
           // removed existing items from those to be imported
           items = await CharacterImport.removeItems(items, compendiumItems);

--- a/src/character/import.js
+++ b/src/character/import.js
@@ -623,7 +623,9 @@ export default class CharacterImport extends Application {
         this.updateCompendium("inventory");
         this.updateCompendium("spells");
         this.updateCompendium("features");
+        /* Issue #263 hotfix - remove Classes Compendium (for now)
         this.updateCompendium("classes");
+        */
 
         // Adding all items to the actor
         const FILTER_SECTIONS = ["classes", "features", "actions", "inventory", "spells"];
@@ -649,12 +651,16 @@ export default class CharacterImport extends Application {
           const compendiumInventoryItems = await CharacterImport.getCompendiumItems(items, "inventory");
           const compendiumSpellItems = await CharacterImport.getCompendiumItems(items, "spells");
           const compendiumFeatureItems = await CharacterImport.getCompendiumItems(items, "features");
+          /* Issue #263 hotfix - remove Classes Compendium (for now)
           const compendiumClassItems = await CharacterImport.getCompendiumItems(items, "classes");
+          */
           compendiumItems = compendiumItems.concat(
             compendiumInventoryItems,
             compendiumSpellItems,
             compendiumFeatureItems,
+            /* Issue #263 hotfix - remove Classes Compendium (for now)
             compendiumClassItems,
+            */
           );
           // removed existing items from those to be imported
           items = await CharacterImport.removeItems(items, compendiumItems);

--- a/src/hooks/ready/checkCompendiums.js
+++ b/src/hooks/ready/checkCompendiums.js
@@ -46,20 +46,20 @@ export default async function () {
     await game.settings.set("vtta-dndbeyond", "entity-feature-compendium", `world.${game.world.name}-ddb-features`);
   }
 
-  compendiumName = game.settings.get("vtta-dndbeyond", "entity-class-compendium");
-  compendium = game.packs.find((pack) => pack.collection === compendiumName);
+  // compendiumName = game.settings.get("vtta-dndbeyond", "entity-class-compendium");
+  // compendium = game.packs.find((pack) => pack.collection === compendiumName);
 
-  if (!compendium) {
-    compendiumCreated = true;
-    // create a compendium for the user
-    await Compendium.create({
-      entity: "Item",
-      label: "My DDB Classes",
-      name: `${game.world.name}-ddb-classes`,
-      package: "world",
-    });
-    await game.settings.set("vtta-dndbeyond", "entity-class-compendium", `world.${game.world.name}-ddb-classes`);
-  }
+  // if (!compendium) {
+  //   compendiumCreated = true;
+  //   // create a compendium for the user
+  //   await Compendium.create({
+  //     entity: "Item",
+  //     label: "My DDB Classes",
+  //     name: `${game.world.name}-ddb-classes`,
+  //     package: "world",
+  //   });
+  //   await game.settings.set("vtta-dndbeyond", "entity-class-compendium", `world.${game.world.name}-ddb-classes`);
+  // }
 
   compendiumName = game.settings.get("vtta-dndbeyond", "entity-monster-compendium");
   compendium = game.packs.find((pack) => pack.collection === compendiumName);

--- a/src/hooks/ready/registerGameSettings.js
+++ b/src/hooks/ready/registerGameSettings.js
@@ -92,15 +92,15 @@ export default function () {
     choices: itemCompendiums,
   });
 
-  game.settings.register("vtta-dndbeyond", "entity-class-compendium", {
-    name: "vtta-dndbeyond.entity-class-compendium.name",
-    hint: "vtta-dndbeyond.entity-class-compendium.hint",
-    scope: "world",
-    config: true,
-    type: String,
-    isSelect: true,
-    choices: itemCompendiums,
-  });
+  // game.settings.register("vtta-dndbeyond", "entity-class-compendium", {
+  //   name: "vtta-dndbeyond.entity-class-compendium.name",
+  //   hint: "vtta-dndbeyond.entity-class-compendium.hint",
+  //   scope: "world",
+  //   config: true,
+  //   type: String,
+  //   isSelect: true,
+  //   choices: itemCompendiums,
+  // });
 
   game.settings.register("vtta-dndbeyond", "entity-spell-compendium", {
     name: "vtta-dndbeyond.entity-spell-compendium.name",


### PR DESCRIPTION
There may be a more elegant way of dealing with this and keeping the My DDB Classes compendium but the current behaviour is quite nasty when importing characters (see Issue #268) so its preferable to disable while we assess whether any better options exist (such as copying the dnd5e system's Classes compendium into My DDB Classes on creation and overriding values of character-specific fields such as "Class Levels" on the Class object with ones from the ddb parse).