### PR TITLE
Added "Monster Features" compendium.

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -23,6 +23,8 @@
   "vtta-dndbeyond.entity-spell-compendium.hint": "Zielkompendium für importierte Zauber",
   "vtta-dndbeyond.entity-monster-compendium.name": "Kompendium für Monster ",
   "vtta-dndbeyond.entity-monster-compendium.hint": "Zielkompendium für importierte Monster",
+  "vtta-dndbeyond.entity-monster-feature-compendium.name": "Needs Translation: Monster features compendium",
+  "vtta-dndbeyond.entity-monster-feature-compendium.hint": "Needs Translation: Target compendium for imported monster features",
   "vtta-dndbeyond.item-type.character": "Spieler",
   "vtta-dndbeyond.item-type.npc": "Monster",
   "vtta-dndbeyond.item-type.spell": "Zauber",

--- a/lang/en.json
+++ b/lang/en.json
@@ -25,6 +25,8 @@
   "vtta-dndbeyond.entity-spell-compendium.hint": "Target compendium for imported spells",
   "vtta-dndbeyond.entity-monster-compendium.name": "Monster compendium",
   "vtta-dndbeyond.entity-monster-compendium.hint": "Target compendium for imported monsters",
+  "vtta-dndbeyond.entity-monster-feature-compendium.name": "Monster features compendium",
+  "vtta-dndbeyond.entity-monster-feature-compendium.hint": "Target compendium for imported monster features",
   "vtta-dndbeyond.item-type.character": "Player",
   "vtta-dndbeyond.item-type.npc": "Monster",
   "vtta-dndbeyond.item-type.spell": "Spell",

--- a/src/hooks/ready/checkCompendiums.js
+++ b/src/hooks/ready/checkCompendiums.js
@@ -1,80 +1,35 @@
 export default async function () {
   let compendiumCreated = false;
 
-  let compendiumName = game.settings.get("vtta-dndbeyond", "entity-spell-compendium");
-  let compendium = game.packs.find((pack) => pack.collection === compendiumName);
-
-  if (!compendium) {
-    compendiumCreated = true;
+  let createIfNotExists = async (settingName, compendiumType, compendiumLabel) => {
+    let compendiumName = game.settings.get("vtta-dndbeyond", settingName);
+    let compendium = game.packs.find((pack) => pack.collection === compendiumName);
+    let sanitizedLabel = sanitize(compendiumLabel);
+    if (compendium) { return false; }
     // create a compendium for the user
     await Compendium.create({
-      entity: "Item",
-      label: "My DDB Spells",
-      name: `${game.world.name}-ddb-spells`,
-      package: "world",
+      entity: compendiumType,
+      label: `My DDB ${compendiumLabel}`,
+      name: `${game.world.name}-ddb-${sanitizedLabel}`,
+      package: "world"
     });
-    await game.settings.set("vtta-dndbeyond", "entity-spell-compendium", `world.${game.world.name}-ddb-spells`);
+    await game.settings.set("vtta-dndbeyond", settingName, `world.${game.world.name}-ddb-${sanitizedLabel}`);
+    return true;
+  };
+
+  let sanitize = (text) => {
+    if (text && typeof text === "string") {
+      return text.replace(/\s/g, '-').toLowerCase();
+    }
+    return text;
   }
 
-  compendiumName = game.settings.get("vtta-dndbeyond", "entity-item-compendium");
-  compendium = game.packs.find((pack) => pack.collection === compendiumName);
-
-  if (!compendium) {
-    compendiumCreated = true;
-    // create a compendium for the user
-    await Compendium.create({
-      entity: "Item",
-      label: "My DDB Items",
-      name: `${game.world.name}-ddb-items`,
-      package: "world",
-    });
-    await game.settings.set("vtta-dndbeyond", "entity-item-compendium", `world.${game.world.name}-ddb-items`);
-  }
-
-  compendiumName = game.settings.get("vtta-dndbeyond", "entity-feature-compendium");
-  compendium = game.packs.find((pack) => pack.collection === compendiumName);
-
-  if (!compendium) {
-    compendiumCreated = true;
-    // create a compendium for the user
-    await Compendium.create({
-      entity: "Item",
-      label: "My DDB Features",
-      name: `${game.world.name}-ddb-features`,
-      package: "world",
-    });
-    await game.settings.set("vtta-dndbeyond", "entity-feature-compendium", `world.${game.world.name}-ddb-features`);
-  }
-
-  // compendiumName = game.settings.get("vtta-dndbeyond", "entity-class-compendium");
-  // compendium = game.packs.find((pack) => pack.collection === compendiumName);
-
-  // if (!compendium) {
-  //   compendiumCreated = true;
-  //   // create a compendium for the user
-  //   await Compendium.create({
-  //     entity: "Item",
-  //     label: "My DDB Classes",
-  //     name: `${game.world.name}-ddb-classes`,
-  //     package: "world",
-  //   });
-  //   await game.settings.set("vtta-dndbeyond", "entity-class-compendium", `world.${game.world.name}-ddb-classes`);
-  // }
-
-  compendiumName = game.settings.get("vtta-dndbeyond", "entity-monster-compendium");
-  compendium = game.packs.find((pack) => pack.collection === compendiumName);
-
-  if (!compendium) {
-    compendiumCreated = true;
-    // create a compendium for the user
-    await Compendium.create({
-      entity: "Actor",
-      label: "My DDB Monsters",
-      name: `${game.world.name}-ddb-monsters`,
-      package: "world",
-    });
-    await game.settings.set("vtta-dndbeyond", "entity-monster-compendium", `world.${game.world.name}-ddb-monsters`);
-  }
+  compendiumCreated = createIfNotExists("entity-spell-compendium", "Item", "Spells")
+    || createIfNotExists("entity-item-compendium", "Item", "Items")
+    || createIfNotExists("entity-feature-compendium", "Item", "Features")
+    || createIfNotExists("entity-monster-compendium", "Actor", "Monsters")
+    //||createIfNotExists("entity-class-compendium", "Item", "Classes")
+    || createIfNotExists("entity-monster-feature-compendium", "Item", "Monster Features");
 
   if (compendiumCreated) location.reload();
 }

--- a/src/hooks/ready/checkCompendiums.js
+++ b/src/hooks/ready/checkCompendiums.js
@@ -24,12 +24,14 @@ export default async function () {
     return text;
   }
 
-  compendiumCreated = createIfNotExists("entity-spell-compendium", "Item", "Spells")
-    || createIfNotExists("entity-item-compendium", "Item", "Items")
-    || createIfNotExists("entity-feature-compendium", "Item", "Features")
-    || createIfNotExists("entity-monster-compendium", "Actor", "Monsters")
-    //||createIfNotExists("entity-class-compendium", "Item", "Classes")
-    || createIfNotExists("entity-monster-feature-compendium", "Item", "Monster Features");
+  let results = await Promise.allSettled([
+    createIfNotExists("entity-spell-compendium", "Item", "Spells"),
+    createIfNotExists("entity-item-compendium", "Item", "Items"),
+    createIfNotExists("entity-feature-compendium", "Item", "Features"),
+    createIfNotExists("entity-monster-compendium", "Actor", "Monsters"),
+    //createIfNotExists("entity-class-compendium", "Item", "Classes"),
+    createIfNotExists("entity-monster-feature-compendium", "Item", "Monster Features")
+  ]);
 
-  if (compendiumCreated) location.reload();
+  if (results.some(result => result.value)) location.reload();
 }

--- a/src/hooks/ready/checkCompendiums.js
+++ b/src/hooks/ready/checkCompendiums.js
@@ -1,11 +1,18 @@
 export default async function () {
-  let compendiumCreated = false;
+  let sanitize = (text) => {
+    if (text && typeof text === "string") {
+      return text.replace(/\s/g, '-').toLowerCase();
+    }
+    return text;
+  };
 
   let createIfNotExists = async (settingName, compendiumType, compendiumLabel) => {
     let compendiumName = game.settings.get("vtta-dndbeyond", settingName);
     let compendium = game.packs.find((pack) => pack.collection === compendiumName);
     let sanitizedLabel = sanitize(compendiumLabel);
-    if (compendium) { return false; }
+    if (compendium) {
+      return false;
+    }
     // create a compendium for the user
     await Compendium.create({
       entity: compendiumType,
@@ -17,21 +24,14 @@ export default async function () {
     return true;
   };
 
-  let sanitize = (text) => {
-    if (text && typeof text === "string") {
-      return text.replace(/\s/g, '-').toLowerCase();
-    }
-    return text;
-  }
-
   let results = await Promise.allSettled([
     createIfNotExists("entity-spell-compendium", "Item", "Spells"),
     createIfNotExists("entity-item-compendium", "Item", "Items"),
     createIfNotExists("entity-feature-compendium", "Item", "Features"),
     createIfNotExists("entity-monster-compendium", "Actor", "Monsters"),
-    //createIfNotExists("entity-class-compendium", "Item", "Classes"),
+    // createIfNotExists("entity-class-compendium", "Item", "Classes"),
     createIfNotExists("entity-monster-feature-compendium", "Item", "Monster Features")
   ]);
 
-  if (results.some(result => result.value)) location.reload();
+  if (results.some((result) => result.value)) location.reload();
 }

--- a/src/hooks/ready/registerGameSettings.js
+++ b/src/hooks/ready/registerGameSettings.js
@@ -122,6 +122,16 @@ export default function () {
     choices: actorCompendiums,
   });
 
+  game.settings.register("vtta-dndbeyond", "entity-monster-feature-compendium", {
+    name: "vtta-dndbeyond.entity-monster-feature-compendium.name",
+    hint: "vtta-dndbeyond.entity-monster-feature-compendium.hint",
+    scope: "world",
+    config: true,
+    type: String,
+    isSelect: true,
+    choices: itemCompendiums,
+  });
+
   /** Character update settings, stored per user and non-configurable in the settings screen */
   game.settings.register("vtta-dndbeyond", "character-update-policy-new", {
     name: "vtta-dndbeyond.character-update-policy-new.name",


### PR DESCRIPTION
This is the first step towards having imported monsters reference a shared list of monster features.  Currently, the module simply creates everything as an action, even if it is not.

Example: Importing an ancient black dragon gives it an action called "Amphibious", which indicates it costs 1 action and allows the black dragon to breathe air and water.  In reality, this should fall under the "Features" subheading of the "Features" tab in the 5E character sheet, and should not require any actions to use.

Behavior can be verified by examining the SRD Adult Black Dragon and it's Amphibious feature, which exists in the Monster Features SRD compendium.