### PR TITLE
prevent button from being added multiple times

### DIFF
--- a/src/hooks/ready/registerSheets.js
+++ b/src/hooks/ready/registerSheets.js
@@ -35,6 +35,9 @@ export default function () {
       // only for GMs or the owner of this character
       if (!data.owner || !data.actor) return;
 
+      // don't add the button multiple times
+      if ($(html).find("#ddbImportButton").length > 0) return;
+
       let button = $('<button type="button" id="ddbImportButton" class="inactive"></button>');
       if (
         app.entity.data.flags.vtta &&
@@ -109,6 +112,10 @@ export default function () {
     Hooks.on("render" + sheetName, (app, html, data) => {
       // only for GMs or the owner of this npc
       if (!data.owner || !data.actor) return;
+
+      // don't add the button multiple times
+      if ($(html).find("#ddbImportButton").length > 0) return;
+
       let button = $('<button type="button" id="ddbImportButton"></button>');
 
       if (


### PR DESCRIPTION
Resolves #301 which describes a problem where the D&D Beyond button gets added to the a tidy5e sheet twice.

This PR fixes the problem by detecting that the button has already been added if render is called multiple times.

