### PR TITLE
Improved error reporting

### DIFF
--- a/src/character/import.js
+++ b/src/character/import.js
@@ -843,13 +843,7 @@ export default class CharacterImport extends Application {
   async parseCharacterData(html, data) {
     // construct the expected { character: {...} } object
     data = data.character === undefined ? { character: data } : data;
-    try {
-      this.result = parser.parseJson(data);
-    } catch (error) {
-      throw new Error(error);
-      // await this.showErrorMessage(html, error);
-      // return false;
-    }
+    this.result = parser.parseJson(data);
 
     utils.log("Parsing finished");
     utils.log(this.result);

--- a/src/character/import.js
+++ b/src/character/import.js
@@ -735,7 +735,17 @@ export default class CharacterImport extends Application {
                 });
 
                 // begin parsing the character data
-                this.parseCharacterData(html, data);
+                try {
+                  this.parseCharacterData(html, data);
+                } catch (error) {
+                  CharacterImport.showCurrentTask(
+                    html,
+                    "Error in parsing character data",
+                    error,
+                    true
+                  );
+                  throw error;
+                }
               }
             })
             .catch(() => {
@@ -765,7 +775,7 @@ export default class CharacterImport extends Application {
           if (characterData.success) {
             data = { character: characterData.data };
             // begin parsing the character data
-            this.parseCharacterData(html, data);
+            await this.parseCharacterData(html, data);
             CharacterImport.showCurrentTask(html, "Loading Character data", "Done.", false);
             this.close();
           } else {
@@ -775,10 +785,10 @@ export default class CharacterImport extends Application {
         } catch (error) {
           switch (error) {
             case "Forbidden":
-              CharacterImport.showCurrentTask(html, "Error retrieving Character: " + error, error, true);
+              CharacterImport.showCurrentTask(html, "Error retrieving Character", error, true);
               break;
             default:
-              CharacterImport.showCurrentTask(html, "Unknown error etrieving Character: " + error, error, true);
+              CharacterImport.showCurrentTask(html, "Unknown error retrieving Character", error, true);
               break;
           }
           return false;

--- a/src/parser/spells/getCharacterSpells.js
+++ b/src/parser/spells/getCharacterSpells.js
@@ -75,6 +75,15 @@ export function getCharacterSpells(ddb, character) {
     // If the spell has an ability attached, use that
     let spellCastingAbility = undefined;
     const classInfo = lookups.classFeature.find((cls) => cls.id === spell.componentId);
+
+    if (!classInfo) {
+      // No class features found with an ID of the given spell.componentId
+      throw new Error(
+        `Unable to associate the spell "${spell.definition.name}" to a class feature ` +
+        `with ID "${spell.componentId}", please log a bug report and supply your character sheet JSON`
+      );
+    }
+
     const klass = utils.getClassFromOptionID(ddb, spell.componentId);
 
     if (hasSpellCastingAbility(spell.spellCastingAbilityId)) {

--- a/src/parser/templateStrings.js
+++ b/src/parser/templateStrings.js
@@ -80,6 +80,14 @@ let parseMatch = (ddb, character, match, feature) => {
       const classOption = [ddb.character.options.race, ddb.character.options.class, ddb.character.options.feat]
         .flat()
         .find((option) => option.definition.id === feature.componentId);
+
+      if (!classOption) {
+        throw new Error(
+          `Unable to associate feature "${feature.name}" to a class via component ID "${feature.componentId}" ` +
+          `to parse the template "${result}", please log a bug report and supply your character sheet JSON`
+        );
+      }
+
       const optionCls = utils.findClassByFeatureId(ddb, classOption.componentId);
       if (optionCls) {
         result = result.replace("classlevel", optionCls.level);

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,7 @@
 import { DND5E } from "../../../systems/dnd5e/module/config.js";
 import DirectoryPicker from "./lib/DirectoryPicker.js";
 import DICTIONARY from "./parser/dictionary.js";
+import logger from "./logger.js";
 
 let utils = {
   debug: () => {
@@ -221,6 +222,11 @@ let utils = {
         return classFeatures.find((feature) => feature.id === featureId) !== undefined;
       }
     });
+
+    if (!cls) {
+      logger.warn(`Unable to find class for feature ID "${featureId}"`);
+    }
+
     return cls;
   },
 


### PR DESCRIPTION
Related to https://github.com/VTTAssets/vtta-dndbeyond/issues/306 and https://github.com/VTTAssets/vtta-dndbeyond/issues/305

There are errors resulting from the importing of a Druid character that employs optional class features from Tasha's Cauldron (https://github.com/VTTAssets/vtta-dndbeyond/issues/306) or a Ranger character using only PHB class features (https://github.com/VTTAssets/vtta-dndbeyond/issues/305). These errors, however, are not being reported all that well.

When a user pastes their JSON character sheet, the import process hangs and the modal does not disappear. Alternatively, when a user imports via the "Start Import" button (where it downloads the character sheet JSON for you), an error is reported in the console but the user is not adequately notified, resulting in the import modal disappearing and leading the user to believe importing was successful.

These changes make it so that the error is more visible to the end user. They do not solve the underlying problem behind the aforementioned issues, however.