### PR TITLE
version bump and point downloads at gh instead of private server

### DIFF
--- a/module.json
+++ b/module.json
@@ -2,7 +2,7 @@
   "name": "vtta-dndbeyond",
   "title": "Virtual Tabletop Assets - D&D Beyond Integration",
   "description": "Bringing your licensed content from D&D Beyond into Foundry VTT",
-  "version": "3.3.2",
+  "version": "3.3.5",
   "minimumCoreVersion": "0.6.0",
   "compatibleCoreVersion": "0.7.1",
   "author": "Sebastian Will",
@@ -44,7 +44,7 @@
   ],
   "packs": [],
   "socket": true,
-  "url": "https://www.vttassets.com/asset/vtta-dndbeyond",
-  "manifest": "https://update.vttassets.com/modules/vtta-dndbeyond/stable/module.json",
-  "download": "https://get.vttassets.com/modules/vtta-dndbeyond/stable"
+  "url": "https://github.com/VTTAssets/vtta-dndbeyond",
+  "manifest": "https://raw.githubusercontent.com/VTTAssets/vtta-dndbeyond/master/module.json",
+  "download": "https://codeload.github.com/VTTAssets/vtta-dndbeyond/zip/3.3.5"
 }


### PR DESCRIPTION
The VTTA server appears to be down, installations and updates are failing at the moment. This will at least allow updates and installations to continue, no telling if the proxy servers are still up and running though.